### PR TITLE
Reduce the length of descriptions and rename parametric axes

### DIFF
--- a/Lib/axisregistry/data/casual.textproto
+++ b/Lib/axisregistry/data/casual.textproto
@@ -16,6 +16,5 @@ fallback {
 fallback_only: false
 illustration_url: "casual.svg"
 description:
-  "Along this axis, letterforms adjust in stroke curvature, contrast, and"
-  " terminals to go from a sturdy, rational 'Linear' style to a friendly,"
-  " energetic 'Casual' style."
+  "Adjust stroke curvature, contrast, and terminals from a sturdy, rational"
+  " Linear style to a friendly, energetic Casual style."

--- a/Lib/axisregistry/data/cursive.textproto
+++ b/Lib/axisregistry/data/cursive.textproto
@@ -22,7 +22,7 @@ fallback {
 fallback_only: true
 illustration_url: "cursive.svg"
 description:
-  "Controls the substitution of cursive forms along the Slant axis. 'Off' (0)"
+  "Control the substitution of cursive forms along the Slant axis. 'Off' (0)"
   " maintains Roman letterforms such as a double-storey a and g, 'Auto' (0.5)"
   " allows for Cursive substitution, and 'On' (1) asserts cursive forms even"
   " in upright text with a Slant of 0."

--- a/Lib/axisregistry/data/fill.textproto
+++ b/Lib/axisregistry/data/fill.textproto
@@ -1,3 +1,4 @@
+# FILL based on https://github.com/google/material-design-icons
 tag: "FILL"
 display_name: "Fill"
 min_value: 0.0
@@ -14,10 +15,8 @@ fallback {
 }
 fallback_only: false
 illustration_url: "fill.svg"
-description: "The Fill axis is intended to provide a treatment of the design"
-  " that fills in transparent forms with opaque ones (and sometimes interior"
-  " opaque forms become transparent, to maintain contrasting shapes)."
-  " Transitions often occur from the center, a side, or a corner,"
-  " but can be in any direction. This can be useful in animation or"
-  " interaction to convey a state transition. The numbers indicate"
-  " proportion filled, from 0 (no treatment) to 1 (completely filled)." 
+description:
+  "Fill in transparent forms with opaque ones. Sometimes interior opaque"
+  " forms become transparent, to maintain contrasting shapes. This can"
+  " be useful in animation or interaction to convey a state transition."
+  " Ranges from 0 (no treatment) to 1 (completely filled)."

--- a/Lib/axisregistry/data/grade.textproto
+++ b/Lib/axisregistry/data/grade.textproto
@@ -12,8 +12,7 @@ fallback {
 fallback_only: false
 illustration_url: "grade.svg"
 description:
-  "Finesse the style from lighter to bolder in typographic color, by varying"
-  " stroke thicknesses or other forms, without any changes overall width,"
-  " inter-letter spacing, or kerning, so there are no changes to line breaks"
-  " or page layout. Negative grade makes the style lighter, while positive"
-  " grade makes it bolder. The units are the same as in the Weight axis."
+  "Finesse the style from lighter to bolder in typographic color, without"
+  " any changes overall width, line breaks or page layout. Negative grade"
+  " makes the style lighter, while positive grade makes it bolder."
+  " The units are the same as in the Weight axis."

--- a/Lib/axisregistry/data/monospace.textproto
+++ b/Lib/axisregistry/data/monospace.textproto
@@ -17,9 +17,7 @@ fallback {
 fallback_only: false
 illustration_url: "monospace.svg"
 description:
-  "Adjust the style from proportional (natural widths, default) to"
-  " monospace (fixed width). Monospace is when all glyphs have the same"
-  " total character width, and more wide or narrow letter proportions to fill"
-  " the space such as a narrower 'w' or wider 'r.' Proportionally spaced"
-  " fonts have letters drawn with more typical proportions, and each glyph"
-  " takes up a unique amount of space on a line."
+  "Adjust the style from Proportional (natural widths, default) to"
+  " Monospace (fixed width). With proportional spacing, each glyph"
+  " takes up a unique amount of space on a line, while monospace"
+  " is when all glyphs have the same total character width."

--- a/Lib/axisregistry/data/optical_size.textproto
+++ b/Lib/axisregistry/data/optical_size.textproto
@@ -94,10 +94,7 @@ fallback {
 fallback_only: false
 illustration_url: "optical_size.svg"
 description:
-  "Adapt the style to specific text sizes, specified in Points. At smaller"
-  " sizes, letters typically become optimized for more legibility, with loose"
-  " spacing/kerning and thicker strokes with less detail. At larger sizes,"
-  " letters are typically optimized for headlines with thinner strokes and"
-  " more detailed forms, and more extreme weights and widths. When used in"
-  " CSS, this axis is activated by default, but not all products/platforms"
-  " use it automatically."
+  "Adapt the style to specific text sizes. At smaller sizes, letters"
+  " typically become optimized for more legibility. At larger sizes,"
+  " optimized for headlines, with more extreme weights and widths."
+  " In CSS this axis is activated by automatically when available."

--- a/Lib/axisregistry/data/softness.textproto
+++ b/Lib/axisregistry/data/softness.textproto
@@ -19,4 +19,5 @@ fallback {
 }
 fallback_only: false
 illustration_url: "softness.svg"
-description: "Letterforms become more soft and rounded."
+description:
+  "Adjust letterforms to become more and more soft and rounded."

--- a/Lib/axisregistry/data/weight.textproto
+++ b/Lib/axisregistry/data/weight.textproto
@@ -46,5 +46,4 @@ illustration_url: "weight.svg"
 description:
   "Adjust the style from lighter to bolder in typographic color, by varying"
   " stroke thicknesses or other forms. This typically changes overall width,"
-  " and so may be used in conjunction with axes for Width and Grade (if"
-  " present)."
+  " and so may be used in conjunction with Width and Grade axes."

--- a/Lib/axisregistry/data/width.textproto
+++ b/Lib/axisregistry/data/width.textproto
@@ -50,7 +50,6 @@ fallback_only: false
 illustration_url: "width.svg"
 description:
   "Adjust the style from narrower to wider, by varying the proportions of"
-  " counters, stems, and other forms including overall spacing and kerning."
-  " This typically changes the apparent weight (what typographers call"
-  " 'typographic color') in a subtle way, and so may be used in conjunction"
-  " with axes for Width and Grade (if present)."
+  " counters, stems, and other forms, including overall spacing and kerning."
+  " This typically changes the typographic color in a subtle way, and so"
+  " may be used in conjunction with Width and Grade axes."

--- a/Lib/axisregistry/data/wonky.textproto
+++ b/Lib/axisregistry/data/wonky.textproto
@@ -16,8 +16,8 @@ fallback {
 fallback_only: true
 illustration_url: "wonky.svg"
 description:
-  "Binary axis to control the subsitution of wonky forms along the"
-  " optical size axis. 'Off' (0) maintains more normalized letterforms,"
-  " such as the leaning n/m/h in roman, or the bulbous flags in the"
-  " b/d/h/k/l of the italic."
-  " In static fonts, this is also available as an OpenType Stylistic Set."
+  "Toggle the subsitution of wonky forms. 'Off' (0) maintains more"
+  " conventional letterforms, while 'On' (1) maintains wonky"
+  " letterforms, such as leaning stems in roman, or flagged"
+  " ascenders in italic. These forms are also controlled by"
+  " Optical Size."

--- a/Lib/axisregistry/data/x_opaque.textproto
+++ b/Lib/axisregistry/data/x_opaque.textproto
@@ -1,6 +1,6 @@
 # XOPQ based on https://variationsguide.typenetwork.com/#xopq
 tag: "XOPQ"
-display_name: "X opaque"
+display_name: "Thick Stroke"
 min_value: -1000
 max_value: 2000
 default_value: 88
@@ -11,4 +11,4 @@ fallback {
 }
 fallback_only: false
 description:
-  "Assigns a 'black' per mille value to each instance of the design space."
+  "A parametric axis for varying thick stroke weights, such as stems."

--- a/Lib/axisregistry/data/x_transparent.textproto
+++ b/Lib/axisregistry/data/x_transparent.textproto
@@ -1,6 +1,6 @@
 # XTRA based on https://variationsguide.typenetwork.com/#xtra
 tag: "XTRA"
-display_name: "X transparent"
+display_name: "Counter Width"
 min_value: -1000
 max_value: 2000
 default_value: 400
@@ -11,4 +11,4 @@ fallback {
 }
 fallback_only: false
 description:
-  "Assigns a 'white'”' per mille value to each instance of the design space."
+  "A parametric axis for varying counter widths in the X dimension."

--- a/Lib/axisregistry/data/y_opaque.textproto
+++ b/Lib/axisregistry/data/y_opaque.textproto
@@ -1,6 +1,6 @@
 # YOPQ based on https://variationsguide.typenetwork.com/#yopq
 tag: "YOPQ"
-display_name: "Y opaque"
+display_name: "Thin Stroke"
 min_value: -1000
 max_value: 2000
 default_value: 116
@@ -11,4 +11,4 @@ fallback {
 }
 fallback_only: false
 description:
-  "Assigns a 'black' per mille value to each instance of the design space."
+  "A parametric axis for varying thin stroke weights, such as bars and hairlines."

--- a/Lib/axisregistry/data/y_transparent_ascender.textproto
+++ b/Lib/axisregistry/data/y_transparent_ascender.textproto
@@ -1,6 +1,6 @@
 # YTAS based on https://variationsguide.typenetwork.com/#ytas
 tag: "YTAS"
-display_name: "Y transparent ascender"
+display_name: "Ascender Height"
 min_value: 0
 max_value: 1000
 default_value: 750
@@ -11,4 +11,4 @@ fallback {
 }
 fallback_only: false
 description:
-  "Assigns a 'white' per mille value to each instance of the design space."
+  "A parametric axis for varying the height of lowercase ascenders."

--- a/Lib/axisregistry/data/y_transparent_descender.textproto
+++ b/Lib/axisregistry/data/y_transparent_descender.textproto
@@ -1,6 +1,6 @@
 # YTDE based on https://variationsguide.typenetwork.com/#ytde
 tag: "YTDE"
-display_name: "Y transparent descender"
+display_name: "Descender Depth"
 min_value: -1000
 max_value: 0
 default_value: -250
@@ -11,4 +11,4 @@ fallback {
 }
 fallback_only: false
 description:
-  "Assigns a 'white' per mille value to each instance of the design space."
+  "A parametric axis for varying the height of lowercase descenders."

--- a/Lib/axisregistry/data/y_transparent_figures.textproto
+++ b/Lib/axisregistry/data/y_transparent_figures.textproto
@@ -1,6 +1,6 @@
 # YTFI based on https://variationsguide.typenetwork.com/#ytfi
 tag: "YTFI"
-display_name: "Y transparent figures"
+display_name: "Figure Height"
 min_value: -1000
 max_value: 2000
 default_value: 600 # this is NOT what TN defined, it's just a value that fits for Roboto Flex
@@ -11,4 +11,4 @@ fallback {
 }
 fallback_only: false
 description:
-  "Assigns a 'white' per mille value to each instance of the design space."
+  "A parametric axis for varying the height of figures."

--- a/Lib/axisregistry/data/y_transparent_lowercase.textproto
+++ b/Lib/axisregistry/data/y_transparent_lowercase.textproto
@@ -1,6 +1,6 @@
 # YTLC based on https://variationsguide.typenetwork.com/#ytlc
 tag: "YTLC"
-display_name: "Y transparent lowercase"
+display_name: "Lowercase Height"
 min_value: 0
 max_value: 1000
 default_value: 500
@@ -11,4 +11,4 @@ fallback {
 }
 fallback_only: false
 description:
-  "Assigns a 'white' per mille value to each instance of the design space."
+  "A parametric axis for varying the height of the lowercase."

--- a/Lib/axisregistry/data/y_transparent_uppercase.textproto
+++ b/Lib/axisregistry/data/y_transparent_uppercase.textproto
@@ -1,6 +1,6 @@
 # YTUC based on https://variationsguide.typenetwork.com/#ytuc
 tag: "YTUC"
-display_name: "Y transparent uppercase"
+display_name: "Uppercase Height"
 min_value: 0
 max_value: 1000
 default_value: 725
@@ -11,4 +11,4 @@ fallback {
 }
 fallback_only: false
 description:
-  "Assigns a 'white' per mille value to each instance of the design space."
+  "A parametric axis for varying the heights of uppercase letterforms."


### PR DESCRIPTION
With the upcoming "tooltips" that explain more about axes, and with the GFK glossary pages describing the axes in more detail, I've made them much shorter.

Parametric axes names are eliding "Parametric" here too.