### PR TITLE
y_transparent_descender.textproto Use depth, not height

### DIFF
--- a/Lib/axisregistry/data/weight.textproto
+++ b/Lib/axisregistry/data/weight.textproto
@@ -45,5 +45,6 @@ fallback_only: false
 illustration_url: "weight.svg"
 description:
   "Adjust the style from lighter to bolder in typographic color, by varying"
-  " stroke thicknesses or other forms. This typically changes overall width,"
-  " and so may be used in conjunction with Width and Grade axes."
+  " stroke weights, spacing and kerning, and other aspects of the type."
+  " This typically changes overall width, and so may be used in conjunction"
+  " with Width and Grade axes."

--- a/Lib/axisregistry/data/width.textproto
+++ b/Lib/axisregistry/data/width.textproto
@@ -50,6 +50,6 @@ fallback_only: false
 illustration_url: "width.svg"
 description:
   "Adjust the style from narrower to wider, by varying the proportions of"
-  " counters, stems, and other forms, including overall spacing and kerning."
+  " counters, strokes, spacing and kerning, and other aspects of the type."
   " This typically changes the typographic color in a subtle way, and so"
   " may be used in conjunction with Width and Grade axes."

--- a/Lib/axisregistry/data/y_transparent_descender.textproto
+++ b/Lib/axisregistry/data/y_transparent_descender.textproto
@@ -12,4 +12,4 @@ fallback {
 fallback_only: false
 illustration_url: "y_transparent_descender.svg"
 description:
-  "A parametric axis for varying the height of lowercase descenders."
+  "A parametric axis for varying the depth of lowercase descenders."


### PR DESCRIPTION
Small copy fixes, for pushing after I/O