### PR TITLE
build_vf_name_table: only use v1 name tables if fvar instances match

### DIFF
--- a/Lib/axisregistry/__init__.py
+++ b/Lib/axisregistry/__init__.py
@@ -132,6 +132,8 @@ class AxisRegistry:
 
 
 axis_registry = AxisRegistry()
+# sort user axes by alphabetical order and append presorted registered axes
+AXIS_ORDER = sorted([i for i in axis_registry if i.isupper()]) + ["opsz", "wdth", "wght", "ital", "slnt"]
 
 
 def is_variable(ttFont):
@@ -281,9 +283,12 @@ def build_vf_name_table(ttFont, family_name, siblings=[]):
 def _vf_style_name(ttFont, family_name):
     fvar_dflts = _fvar_dflts(ttFont)
     res = []
-    for k, v in fvar_dflts.items():
-        if not v["elided"]:
-            res.append(v["name"])
+    for axis_name in AXIS_ORDER:
+        if axis_name not in fvar_dflts:
+            continue
+        value = fvar_dflts[axis_name]
+        if not value["elided"]:
+            res.append(value["name"])
 
     family_name_tokens = family_name.split()
     font_styles = axis_registry.fallbacks_in_name_table(ttFont)

--- a/Lib/axisregistry/__init__.py
+++ b/Lib/axisregistry/__init__.py
@@ -245,15 +245,15 @@ def build_name_table(ttFont, family_name=None, style_name=None, siblings=[]):
 
 
 def _fvar_instance_collisions(ttFont, siblings=[]):
-    """Check if a collection of fonts are going to have the same fvar instances."""
-    fallbacks = axis_registry.fallbacks_in_fvar(ttFont)
-    is_italic = ttFont['post'].italicAngle != 0.0
-    for sibling in siblings:
-        sibling_fallbacks = axis_registry.fallbacks_in_fvar(sibling)
-        sibling_italic = sibling['post'].italicAngle != 0.0
-        if sibling_fallbacks == fallbacks and is_italic == sibling_italic:
-            return True
-    return False
+    """Check if a font family is going to have colliding fvar instances.
+
+    Collision occur when a family has has 2+ roman styles or 2+ italic
+    styles."""
+    def is_italic(font):
+        return font['post'].italicAngle != 0.0
+    family_styles = [is_italic(f) for f in siblings + [ttFont]]
+
+    return len(family_styles) != len(set(family_styles))
 
 
 def build_vf_name_table(ttFont, family_name, siblings=[]):

--- a/Lib/axisregistry/__init__.py
+++ b/Lib/axisregistry/__init__.py
@@ -133,7 +133,13 @@ class AxisRegistry:
 
 axis_registry = AxisRegistry()
 # sort user axes by alphabetical order and append presorted registered axes
-AXIS_ORDER = sorted([i for i in axis_registry if i.isupper()]) + ["opsz", "wdth", "wght", "ital", "slnt"]
+AXIS_ORDER = sorted([i for i in axis_registry if i.isupper()]) + [
+    "opsz",
+    "wdth",
+    "wght",
+    "ital",
+    "slnt",
+]
 
 
 def is_variable(ttFont):
@@ -249,8 +255,10 @@ def _fvar_instance_collisions(ttFont, siblings=[]):
 
     Collision occur when a family has has 2+ roman styles or 2+ italic
     styles."""
+
     def is_italic(font):
-        return font['post'].italicAngle != 0.0
+        return font["post"].italicAngle != 0.0
+
     family_styles = [is_italic(f) for f in siblings + [ttFont]]
 
     return len(family_styles) != len(set(family_styles))

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -295,6 +295,7 @@ def _test_names(ttFont, expected):
 )
 def test_name_table(fp, family_name, style_name, siblings, expected):
     font = TTFont(fp)
+    siblings = [TTFont(fp) for fp in siblings]
     build_name_table(font, family_name, style_name, siblings)
     _test_names(font, expected)
 


### PR DESCRIPTION
If a variable font family has two or more fonts and their fvar instances match (excluding roman + ital families), we must use the v1 name table builder. This builder appends style variants which are not weight or italic to the family name. By doing this we won't get fvar instance collisions since the families have been split into two distinct families.

An example within out catalog is Cabin e.g:
Cabin[wght].ttf + CabinCondensed[wght].ttf