### PR TITLE
Fix typo and ensure tox runs tests correctly

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,7 +23,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install tox tox-gh-actions pytest
 
     - name: Test with tox
-      run: tox
+      run: |
+        tox -e py
+        tox -e lint

--- a/Lib/axisregistry/__init__.py
+++ b/Lib/axisregistry/__init__.py
@@ -324,7 +324,9 @@ def build_fvar_instances(ttFont, axis_dflts={}):
     stat_nameids = []
     if "STAT" in ttFont:
         if ttFont["STAT"].table.AxisValueCount > 0:
-            stat_nameids = [av.ValueNameID for av in ttFont["STAT"].table.AxisValueArray.AxisValue]
+            stat_nameids = [
+                av.ValueNameID for av in ttFont["STAT"].table.AxisValueArray.AxisValue
+            ]
 
     # rm old fvar subfamily and ps name records
     for inst in fvar.instances:

--- a/Lib/axisregistry/__init__.py
+++ b/Lib/axisregistry/__init__.py
@@ -323,7 +323,7 @@ def build_fvar_instances(ttFont, axis_dflts={}):
     # Protect name IDs which are shared with the STAT table
     stat_nameids = []
     if "STAT" in ttFont:
-        if stat.table.AxisValueCount > 0:
+        if ttFont["STAT"].table.AxisValueCount > 0:
             stat_nameids = [av.ValueNameID for av in ttFont["STAT"].table.AxisValueArray.AxisValue]
 
     # rm old fvar subfamily and ps name records

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setup(
     ],
     python_requires=">=3.7",
     setup_requires=["setuptools_scm>=4,<6.1"],
-    install_requires=["protobuf"],
+    install_requires=["protobuf==3.19.4", "fonttools"],
 )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,5 @@
+pytest>=4.5.0
+coverage>=5
+black
+isort
+flake8-bugbear

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -500,7 +500,7 @@ def test_filename(fp, expected):
         (opensans_roman_fp, [opensans_cond_roman_fp], True),
         (opensans_roman_fp, [opensans_italic_fp], False),
         (wonky_fp, [], False),
-    ]
+    ],
 )
 def test_fvar_instance_collisions(fp, sibling_fps, result):
     ttFont = TTFont(fp)

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ skip_install = true
 deps =
     -r test_requirements.txt
 commands =
-    black --check --diff .
+    black --check --diff --extend-exclude "_version.py" .
 
 [testenv:coverage-report]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,6 @@ deps =
     -r test_requirements.txt
 commands =
     black --check --diff .
-    isort --check-only --diff .
-    flake8
 
 [testenv:coverage-report]
 skip_install = true


### PR DESCRIPTION
#49 ran without a hitch because I stupidly forgot to wire up the unit tests. This PR will fix the typo which passed in that pr and also enable tests for tox.