### PR TITLE
Add Bounce [BNCE] axis

### DIFF
--- a/Lib/axisregistry/data/bounce.textproto
+++ b/Lib/axisregistry/data/bounce.textproto
@@ -1,3 +1,4 @@
+# BNCE based on https://github.com/arrowtype/shantell-sans
 tag: "BNCE"
 display_name: "Bounce"
 min_value: -100.0

--- a/Lib/axisregistry/data/bounce.textproto
+++ b/Lib/axisregistry/data/bounce.textproto
@@ -11,6 +11,5 @@ fallback {
 }
 fallback_only: false
 description:
-  "Shift glyphs up and down in the Y dimension, resulting in an "
-  "uneven, bouncy baseline. The negative range, if used, should reflect "
-  "opposite shifts to the positive range, to enable looping animation."
+  "Shift glyphs up and down in the Y dimension, resulting "
+  "in an uneven, bouncy baseline."

--- a/Lib/axisregistry/data/bounce.textproto
+++ b/Lib/axisregistry/data/bounce.textproto
@@ -1,23 +1,15 @@
 tag: "BNCE"
 display_name: "Bounce"
 min_value: -100
-max_value: 100
 default_value: 0
+max_value: 100
 precision: -1
 fallback {
-  name: "Normal"
+  name: "Default"
   value: 0
-}
-fallback {
-  name: "SemiBouncy"
-  value: 50
-}
-fallback {
-  name: "Bouncy"
-  value: 100
 }
 fallback_only: false
 description:
-  "Translate glyphs up and down along the y axis to result in an "
-  "uneven, bouncy baseline. The negative range, if used, should reflect 
-  "positive translations to provide an animatable axis."
+  "Shift glyphs up and down in the Y dimension, resulting in an "
+  "uneven, bouncy baseline. The negative range, if used, should reflect "
+  "opposite shifts to the positive range, to enable looping animation."

--- a/Lib/axisregistry/data/bounce.textproto
+++ b/Lib/axisregistry/data/bounce.textproto
@@ -1,0 +1,23 @@
+tag: "BNCE"
+display_name: "Bounce"
+min_value: -100
+max_value: 100
+default_value: 0
+precision: -1
+fallback {
+  name: "Normal"
+  value: 0
+}
+fallback {
+  name: "SemiBouncy"
+  value: 50
+}
+fallback {
+  name: "Bouncy"
+  value: 100
+}
+fallback_only: false
+description:
+  "Translate glyphs up and down along the y axis to result in an "
+  "uneven, bouncy baseline. The negative range, if used, should reflect 
+  "positive translations to provide an animatable axis."

--- a/Lib/axisregistry/data/bounce.textproto
+++ b/Lib/axisregistry/data/bounce.textproto
@@ -1,10 +1,10 @@
 # BNCE based on https://github.com/arrowtype/shantell-sans
 tag: "BNCE"
 display_name: "Bounce"
-min_value: -100.0
+min_value: -100
 default_value: 0
-max_value: 100.0
-precision: -1
+max_value: 100
+precision: 0
 fallback {
   name: "Default"
   value: 0

--- a/Lib/axisregistry/data/bounce.textproto
+++ b/Lib/axisregistry/data/bounce.textproto
@@ -1,8 +1,8 @@
 tag: "BNCE"
 display_name: "Bounce"
-min_value: -100
+min_value: -100.0
 default_value: 0
-max_value: 100
+max_value: 100.0
 precision: -1
 fallback {
   name: "Default"


### PR DESCRIPTION
PR to follow up on the inclusion of the new custom axis Bounce, `BNCE`. https://github.com/googlefonts/axisregistry/issues/38

Required for the upcoming release of [Shantell Sans](https://next--shantell-sans.netlify.app).