### PR TITLE
Add custom axis for Irregularity (IRGL)

### DIFF
--- a/Lib/axisregistry/data/irregularity.textproto
+++ b/Lib/axisregistry/data/irregularity.textproto
@@ -1,0 +1,23 @@
+tag: "IRGL"
+display_name: "Irregularity"
+min_value: 0
+max_value: 100
+default_value: 0
+precision: -1
+fallback {
+  name: "Normal"
+  value: 0
+}
+fallback {
+  name: "Irregularish"
+  value: 50
+}
+fallback {
+  name: "Irregular"
+  value: 100
+}
+fallback_only: false
+description:
+  "Adjust glyph shapes from normalized proportions to irregular shaping and sizing. "
+  "Intended especially for handwriting-themed fonts which seek to provide "
+  "a range of from highly readable to highly expressive."


### PR DESCRIPTION
PR to follow up on the inclusion of the new custom axis Irregularity, `IRGL`: https://github.com/googlefonts/axisregistry/issues/37

Required for the upcoming release of [Shantell Sans](https://next--shantell-sans.netlify.app/).