### PR TITLE
Sync googlefonts/axisregistry with google/fonts axisregistry directory

### DIFF
--- a/Lib/axisregistry/__init__.py
+++ b/Lib/axisregistry/__init__.py
@@ -53,6 +53,32 @@ GF_STATIC_STYLES = OrderedDict(
 )
 
 
+    for axis in [
+        "casual.textproto",
+        "cursive.textproto",
+        "fill.textproto",
+        "flair.textproto",
+        "grade.textproto",
+        "italic.textproto",
+        "monospace.textproto",
+        "optical_size.textproto",
+        "slant.textproto",
+        "softness.textproto",
+        "volume.textproto",
+        "weight.textproto",
+        "width.textproto",
+        "wonky.textproto",
+        "x_opaque.textproto",
+        "x_transparent_figures.textproto",
+        "x_transparent.textproto",
+        "y_opaque.textproto",
+        "y_transparent_ascender.textproto",
+        "y_transparent_descender.textproto",
+        "y_transparent_figures.textproto",
+        "y_transparent_lowercase.textproto",
+        "y_transparent_uppercase.textproto",
+    ]:
+        append_AxisMessage(resource_filename("axisregistry", "data/" + axis))
 def load_protobuf(klass, path):
     message = klass()
     with open(path, "rb") as text_data:

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ deps =
     -r test_requirements.txt
 commands =
     black --check --diff --extend-exclude "_version.py" .
+    isort --check-only --diff .
+    flake8
 
 [testenv:coverage-report]
 skip_install = true


### PR DESCRIPTION
The changes here bring this repository into sync with the changes agreed upon in https://github.com/google/fonts/pull/5072

Following this edit, all new axisregistry changes will take place in this repository and will be git subtree pulled into the google/fonts repository.