### PR TITLE
Sync axis registration changes with google/fonts axisregistry directory

### DIFF
--- a/Lib/axisregistry/data/edge_highlight.textproto
+++ b/Lib/axisregistry/data/edge_highlight.textproto
@@ -11,3 +11,4 @@ fallback {
   name: "Default"
   value: 12
 }
+fallback_only: false

--- a/Lib/axisregistry/data/element_grid.textproto
+++ b/Lib/axisregistry/data/element_grid.textproto
@@ -11,3 +11,4 @@ fallback {
   name: "Default"
   value: 1.0
 }
+fallback_only: false

--- a/Lib/axisregistry/data/extrusion_depth.textproto
+++ b/Lib/axisregistry/data/extrusion_depth.textproto
@@ -11,3 +11,4 @@ fallback {
   name: "Default"
   value: 100
 }
+fallback_only: false


### PR DESCRIPTION
We'll sync this repo with google/fonts axisregistry directory in two stages.  First step here is to bring in all downstream edits to textproto files that we want to preserve.  The second stage will be to git subtree pull this repo into google/fonts axisregistry directory and take all other changes from this side.  We should then be in sync and can use edits here only and git subtree pulls to import axisregistry edits into google/fonts

cc @rsheeter 