### PR TITLE
italic.textproto reduce precision from -1 to 0

### DIFF
--- a/Lib/axisregistry/data/italic.textproto
+++ b/Lib/axisregistry/data/italic.textproto
@@ -4,7 +4,7 @@ display_name: "Italic"
 min_value: 0
 max_value: 1
 default_value: 0
-precision: -1
+precision: 0
 fallback {
   name: "Roman"
   value: 0


### PR DESCRIPTION
Since we don't support the ital axis, in fact, and require separate roman and italic files at the moment (due to concerns eg in https://arrowtype.github.io/vf-slnt-test), then we should reflect that actual implementation in the axis definition. 

Since we have zero families with an ital axis, this should be a no-op when pushed; but this is a very peculiar move, and may have unexpected consequences when pushed.