### PR TITLE
build_stat: do not rm fvar axis name records

### DIFF
--- a/Lib/axisregistry/__init__.py
+++ b/Lib/axisregistry/__init__.py
@@ -176,7 +176,9 @@ def build_stat(ttFont, sibling_ttFonts=[]):
     fvar = ttFont["fvar"]
 
     # rm old STAT table and associated name table records
-    fvar_nameids = set(i.subfamilyNameID for i in fvar.instances)
+    fvar_instance_nameids = set(i.subfamilyNameID for i in fvar.instances)
+    fvar_axis_nameids = set(a.axisNameID for a in fvar.axes)
+    fvar_nameids = fvar_axis_nameids | fvar_instance_nameids
     if "STAT" in ttFont:
         stat = ttFont["STAT"]
         if stat.table.AxisValueCount > 0:

--- a/tests/data/OpenSans-Italic[wdth,wght]_STAT.ttx
+++ b/tests/data/OpenSans-Italic[wdth,wght]_STAT.ttx
@@ -4,12 +4,12 @@
 <DesignAxisRecord>
   <Axis index="0">
     <AxisTag value="wght"/>
-    <AxisNameID value="280"/>  <!-- Weight -->
+    <AxisNameID value="256"/>  <!-- Weight -->
     <AxisOrdering value="0"/>
   </Axis>
   <Axis index="1">
     <AxisTag value="wdth"/>
-    <AxisNameID value="287"/>  <!-- Width -->
+    <AxisNameID value="257"/>  <!-- Width -->
     <AxisOrdering value="1"/>
   </Axis>
   <Axis index="2">
@@ -28,56 +28,56 @@
   <AxisValue index="0" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="281"/>  <!-- Light -->
+    <ValueNameID value="280"/>  <!-- Light -->
     <Value value="300.0"/>
   </AxisValue>
   <AxisValue index="1" Format="3">
     <AxisIndex value="0"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="282"/>  <!-- Regular -->
+    <ValueNameID value="281"/>  <!-- Regular -->
     <Value value="400.0"/>
     <LinkedValue value="700.0"/>
   </AxisValue>
   <AxisValue index="2" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="283"/>  <!-- Medium -->
+    <ValueNameID value="282"/>  <!-- Medium -->
     <Value value="500.0"/>
   </AxisValue>
   <AxisValue index="3" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="284"/>  <!-- SemiBold -->
+    <ValueNameID value="283"/>  <!-- SemiBold -->
     <Value value="600.0"/>
   </AxisValue>
   <AxisValue index="4" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="285"/>  <!-- Bold -->
+    <ValueNameID value="284"/>  <!-- Bold -->
     <Value value="700.0"/>
   </AxisValue>
   <AxisValue index="5" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="286"/>  <!-- ExtraBold -->
+    <ValueNameID value="285"/>  <!-- ExtraBold -->
     <Value value="800.0"/>
   </AxisValue>
   <AxisValue index="6" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="288"/>  <!-- Condensed -->
+    <ValueNameID value="286"/>  <!-- Condensed -->
     <Value value="75.0"/>
   </AxisValue>
   <AxisValue index="7" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="289"/>  <!-- SemiCondensed -->
+    <ValueNameID value="287"/>  <!-- SemiCondensed -->
     <Value value="87.5"/>
   </AxisValue>
   <AxisValue index="8" Format="1">
     <AxisIndex value="1"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="290"/>  <!-- Normal -->
+    <ValueNameID value="288"/>  <!-- Normal -->
     <Value value="100.0"/>
   </AxisValue>
   <AxisValue index="9" Format="1">
@@ -89,7 +89,7 @@
   <AxisValue index="10" Format="3">
     <AxisIndex value="3"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="290"/>  <!-- Normal -->
+    <ValueNameID value="288"/>  <!-- Normal -->
     <Value value="0.0"/>
     <LinkedValue value="1.0"/>
   </AxisValue>

--- a/tests/data/OpenSansCondensed-Italic[wght]_STAT.ttx
+++ b/tests/data/OpenSansCondensed-Italic[wght]_STAT.ttx
@@ -4,7 +4,7 @@
 <DesignAxisRecord>
   <Axis index="0">
     <AxisTag value="wght"/>
-    <AxisNameID value="521"/>  <!-- Weight -->
+    <AxisNameID value="256"/>  <!-- Weight -->
     <AxisOrdering value="0"/>
   </Axis>
   <Axis index="1">
@@ -33,50 +33,50 @@
   <AxisValue index="0" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="522"/>  <!-- Thin -->
+    <ValueNameID value="521"/>  <!-- Thin -->
     <Value value="100.0"/>
   </AxisValue>
   <AxisValue index="1" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="523"/>  <!-- ExtraLight -->
+    <ValueNameID value="522"/>  <!-- ExtraLight -->
     <Value value="200.0"/>
   </AxisValue>
   <AxisValue index="2" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="524"/>  <!-- Light -->
+    <ValueNameID value="523"/>  <!-- Light -->
     <Value value="300.0"/>
   </AxisValue>
   <AxisValue index="3" Format="3">
     <AxisIndex value="0"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="525"/>  <!-- Regular -->
+    <ValueNameID value="524"/>  <!-- Regular -->
     <Value value="400.0"/>
     <LinkedValue value="700.0"/>
   </AxisValue>
   <AxisValue index="4" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="526"/>  <!-- Medium -->
+    <ValueNameID value="525"/>  <!-- Medium -->
     <Value value="500.0"/>
   </AxisValue>
   <AxisValue index="5" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="527"/>  <!-- SemiBold -->
+    <ValueNameID value="526"/>  <!-- SemiBold -->
     <Value value="600.0"/>
   </AxisValue>
   <AxisValue index="6" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="528"/>  <!-- Bold -->
+    <ValueNameID value="527"/>  <!-- Bold -->
     <Value value="700.0"/>
   </AxisValue>
   <AxisValue index="7" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="529"/>  <!-- ExtraBold -->
+    <ValueNameID value="528"/>  <!-- ExtraBold -->
     <Value value="800.0"/>
   </AxisValue>
   <AxisValue index="8" Format="1">
@@ -94,14 +94,14 @@
   <AxisValue index="10" Format="3">
     <AxisIndex value="3"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="530"/>  <!-- Normal -->
+    <ValueNameID value="529"/>  <!-- Normal -->
     <Value value="0.0"/>
     <LinkedValue value="1.0"/>
   </AxisValue>
   <AxisValue index="11" Format="1">
     <AxisIndex value="4"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="530"/>  <!-- Normal -->
+    <ValueNameID value="529"/>  <!-- Normal -->
     <Value value="0.0"/>
   </AxisValue>
 </AxisValueArray>

--- a/tests/data/OpenSansCondensed[wght]_STAT.ttx
+++ b/tests/data/OpenSansCondensed[wght]_STAT.ttx
@@ -4,7 +4,7 @@
 <DesignAxisRecord>
   <Axis index="0">
     <AxisTag value="wght"/>
-    <AxisNameID value="466"/>  <!-- Weight -->
+    <AxisNameID value="256"/>  <!-- Weight -->
     <AxisOrdering value="0"/>
   </Axis>
   <Axis index="1">

--- a/tests/data/OpenSans[wdth,wght]_STAT.ttx
+++ b/tests/data/OpenSans[wdth,wght]_STAT.ttx
@@ -4,22 +4,22 @@
 <DesignAxisRecord>
   <Axis index="0">
     <AxisTag value="wght"/>
-    <AxisNameID value="280"/>  <!-- Weight -->
+    <AxisNameID value="256"/>  <!-- Weight -->
     <AxisOrdering value="0"/>
   </Axis>
   <Axis index="1">
     <AxisTag value="wdth"/>
-    <AxisNameID value="282"/>  <!-- Width -->
+    <AxisNameID value="257"/>  <!-- Width -->
     <AxisOrdering value="1"/>
   </Axis>
   <Axis index="2">
     <AxisTag value="ital"/>
-    <AxisNameID value="286"/>  <!-- Italic -->
+    <AxisNameID value="284"/>  <!-- Italic -->
     <AxisOrdering value="2"/>
   </Axis>
   <Axis index="3">
     <AxisTag value="ital"/>
-    <AxisNameID value="286"/>  <!-- Italic -->
+    <AxisNameID value="284"/>  <!-- Italic -->
     <AxisOrdering value="3"/>
   </Axis>
 </DesignAxisRecord>
@@ -41,7 +41,7 @@
   <AxisValue index="2" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="281"/>  <!-- Medium -->
+    <ValueNameID value="280"/>  <!-- Medium -->
     <Value value="500.0"/>
   </AxisValue>
   <AxisValue index="3" Format="1">
@@ -65,32 +65,32 @@
   <AxisValue index="6" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="283"/>  <!-- Condensed -->
+    <ValueNameID value="281"/>  <!-- Condensed -->
     <Value value="75.0"/>
   </AxisValue>
   <AxisValue index="7" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="284"/>  <!-- SemiCondensed -->
+    <ValueNameID value="282"/>  <!-- SemiCondensed -->
     <Value value="87.5"/>
   </AxisValue>
   <AxisValue index="8" Format="1">
     <AxisIndex value="1"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="285"/>  <!-- Normal -->
+    <ValueNameID value="283"/>  <!-- Normal -->
     <Value value="100.0"/>
   </AxisValue>
   <AxisValue index="9" Format="3">
     <AxisIndex value="2"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="285"/>  <!-- Normal -->
+    <ValueNameID value="283"/>  <!-- Normal -->
     <Value value="0.0"/>
     <LinkedValue value="1.0"/>
   </AxisValue>
   <AxisValue index="10" Format="3">
     <AxisIndex value="3"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="285"/>  <!-- Normal -->
+    <ValueNameID value="283"/>  <!-- Normal -->
     <Value value="0.0"/>
     <LinkedValue value="1.0"/>
   </AxisValue>

--- a/tests/data/Wonky[wdth,wght]_STAT.ttx
+++ b/tests/data/Wonky[wdth,wght]_STAT.ttx
@@ -4,12 +4,12 @@
 <DesignAxisRecord>
   <Axis index="0">
     <AxisTag value="wght"/>
-    <AxisNameID value="280"/>  <!-- Weight -->
+    <AxisNameID value="256"/>  <!-- Weight -->
     <AxisOrdering value="0"/>
   </Axis>
   <Axis index="1">
     <AxisTag value="wdth"/>
-    <AxisNameID value="282"/>  <!-- Width -->
+    <AxisNameID value="257"/>  <!-- Width -->
     <AxisOrdering value="1"/>
   </Axis>
 </DesignAxisRecord>
@@ -31,7 +31,7 @@
   <AxisValue index="2" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="281"/>  <!-- Medium -->
+    <ValueNameID value="280"/>  <!-- Medium -->
     <Value value="500.0"/>
   </AxisValue>
   <AxisValue index="3" Format="1">
@@ -55,19 +55,19 @@
   <AxisValue index="6" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="283"/>  <!-- Condensed -->
+    <ValueNameID value="281"/>  <!-- Condensed -->
     <Value value="75.0"/>
   </AxisValue>
   <AxisValue index="7" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="284"/>  <!-- SemiCondensed -->
+    <ValueNameID value="282"/>  <!-- SemiCondensed -->
     <Value value="87.5"/>
   </AxisValue>
   <AxisValue index="8" Format="1">
     <AxisIndex value="1"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="285"/>  <!-- Normal -->
+    <ValueNameID value="283"/>  <!-- Normal -->
     <Value value="100.0"/>
   </AxisValue>
 </AxisValueArray>


### PR DESCRIPTION
When a user runs `build_stat`, it will remove any name records which are associated with the old stat table. However, Stat axis names and fvar axis name often use the name record. If a name record is also being used for an fvar axis name, we should skip it,


Fixes https://github.com/googlefonts/gftools/issues/619

cc @simoncozens 