### PR TITLE
fix_stat do not drop nameids <= 25

### DIFF
--- a/Lib/axisregistry/__init__.py
+++ b/Lib/axisregistry/__init__.py
@@ -179,17 +179,21 @@ def build_stat(ttFont, sibling_ttFonts=[]):
     fvar_instance_nameids = set(i.subfamilyNameID for i in fvar.instances)
     fvar_axis_nameids = set(a.axisNameID for a in fvar.axes)
     fvar_nameids = fvar_axis_nameids | fvar_instance_nameids
+    # These NameIDs are required for applications to work correctly so
+    # they cannot be deleted.
+    # https://learn.microsoft.com/en-us/typography/opentype/spec/name
+    keep_nameids = set(range(26)) | fvar_nameids
     if "STAT" in ttFont:
         stat = ttFont["STAT"]
         if stat.table.AxisValueCount > 0:
             axis_values = stat.table.AxisValueArray.AxisValue
             for ax in axis_values:
-                if ax.ValueNameID not in fvar_nameids:
+                if ax.ValueNameID not in keep_nameids:
                     nametable.removeNames(nameID=ax.ValueNameID)
         if stat.table.DesignAxisCount > 0:
             axes = stat.table.DesignAxisRecord.Axis
             for ax in axes:
-                if ax.AxisNameID not in fvar_nameids:
+                if ax.AxisNameID not in keep_nameids:
                     nametable.removeNames(nameID=ax.AxisNameID)
         del ttFont["STAT"]
 

--- a/tests/data/OpenSansCondensed-Italic[wght]_STAT.ttx
+++ b/tests/data/OpenSansCondensed-Italic[wght]_STAT.ttx
@@ -88,7 +88,7 @@
   <AxisValue index="9" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="17"/>  <!-- Italic -->
+    <ValueNameID value="2"/>  <!-- Italic -->
     <Value value="1.0"/>
   </AxisValue>
   <AxisValue index="10" Format="3">
@@ -105,4 +105,4 @@
     <Value value="0.0"/>
   </AxisValue>
 </AxisValueArray>
-<ElidedFallbackNameID value="2"/>  <!-- missing from name table -->
+<ElidedFallbackNameID value="2"/>  <!-- Italic -->

--- a/tests/data/OpenSansCondensed[wght]_STAT.ttx
+++ b/tests/data/OpenSansCondensed[wght]_STAT.ttx
@@ -51,7 +51,7 @@
   <AxisValue index="3" Format="3">
     <AxisIndex value="0"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="260"/>  <!-- Regular -->
+    <ValueNameID value="2"/>  <!-- Regular -->
     <Value value="400.0"/>
     <LinkedValue value="700.0"/>
   </AxisValue>
@@ -106,4 +106,4 @@
     <LinkedValue value="1.0"/>
   </AxisValue>
 </AxisValueArray>
-<ElidedFallbackNameID value="2"/>  <!-- missing from name table -->
+<ElidedFallbackNameID value="2"/>  <!-- Regular -->


### PR DESCRIPTION
In https://github.com/google/fonts/pull/5338, we're finding that build_stat is removing nameID 2 when it should be preserved. In fact, all nameIDs <= 25 are used in font application menus so they should all be preserved.

cc @simoncozens 