### PR TITLE
Add Informality [INFM] axis

### DIFF
--- a/Lib/axisregistry/data/informality.textproto
+++ b/Lib/axisregistry/data/informality.textproto
@@ -11,6 +11,5 @@ fallback {
 }
 fallback_only: false
 description:
-  "Adjusts overall design and glyph shapes, providing a stylistic change"
-  " from formal and traditional (0%) to informal and unconventional"
-  " (up to 100%)."
+  "Adjusts overall design from formal and traditional (0%)"
+  " to informal and unconventional (up to 100%)."

--- a/Lib/axisregistry/data/informality.textproto
+++ b/Lib/axisregistry/data/informality.textproto
@@ -11,7 +11,6 @@ fallback {
 }
 fallback_only: false
 description:
-  "Adjust overall glyph shaping and design from traditional to inventive. "
-  "Intended especially for fonts which seek to provide a stylistic range "
-  "from highly readable to highly expressive."
-
+  "Adjusts overall design and glyph shapes, providing a stylistic change"
+  " from formal and traditional (0%) to informal and unconventional"
+  " (up to 100%)."

--- a/Lib/axisregistry/data/informality.textproto
+++ b/Lib/axisregistry/data/informality.textproto
@@ -1,0 +1,17 @@
+# INFM based on https://github.com/arrowtype/shantell-sans
+tag: "INFM"
+display_name: "Informality"
+min_value: 0
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0
+}
+fallback_only: false
+description:
+  "Adjust overall glyph shaping and design from traditional to inventive. "
+  "Intended especially for fonts which seek to provide a stylistic range "
+  "from highly readable to highly expressive."
+


### PR DESCRIPTION
PR to follow up on the inclusion of the new custom axis required for [Shantell Sans](https://next--shantell-sans.netlify.app/), it would replace originally proposed Irregularity https://github.com/googlefonts/axisregistry/issues/37

@thundernixon I'm opening this new PR since the textproto file name also needed to change.