### PR TITLE
build_stat: improve elided axisvalues

### DIFF
--- a/Lib/axisregistry/__init__.py
+++ b/Lib/axisregistry/__init__.py
@@ -234,14 +234,17 @@ def build_stat(ttFont, sibling_ttFonts=[]):
     for axis, fallback in fallbacks_in_siblings:
         if axis in seen_axes:
             continue
-        value = 0.0
+        elided_value = axis_registry[axis].default_value
+        elided_fallback = axis_registry.fallback_for_value(axis, elided_value)
         a = {
             "tag": axis,
             "name": axis_registry[axis].display_name,
-            "values": [{"name": "Normal", "value": value, "flags": 0x2}],
+            "values": [
+                {"name": elided_fallback.name, "value": elided_value, "flags": 0x2}
+            ],
         }
-        if axis in LINKED_VALUES and value in LINKED_VALUES[axis]:
-            a["values"][0]["linkedValue"] = LINKED_VALUES[axis][value]
+        if axis in LINKED_VALUES and elided_value in LINKED_VALUES[axis]:
+            a["values"][0]["linkedValue"] = LINKED_VALUES[axis][elided_value]
         res.append(a)
     buildStatTable(ttFont, res, macNames=False)
 

--- a/tests/data/OpenSans-Italic[wdth,wght]_STAT.ttx
+++ b/tests/data/OpenSans-Italic[wdth,wght]_STAT.ttx
@@ -89,7 +89,7 @@
   <AxisValue index="10" Format="3">
     <AxisIndex value="3"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="288"/>  <!-- Normal -->
+    <ValueNameID value="289"/>  <!-- Roman -->
     <Value value="0.0"/>
     <LinkedValue value="1.0"/>
   </AxisValue>

--- a/tests/data/OpenSansCondensed-Italic[wght]_STAT.ttx
+++ b/tests/data/OpenSansCondensed-Italic[wght]_STAT.ttx
@@ -94,15 +94,15 @@
   <AxisValue index="10" Format="3">
     <AxisIndex value="3"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="529"/>  <!-- Normal -->
+    <ValueNameID value="529"/>  <!-- Roman -->
     <Value value="0.0"/>
     <LinkedValue value="1.0"/>
   </AxisValue>
   <AxisValue index="11" Format="1">
     <AxisIndex value="4"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="529"/>  <!-- Normal -->
-    <Value value="0.0"/>
+    <ValueNameID value="530"/>  <!-- Normal -->
+    <Value value="100.0"/>
   </AxisValue>
 </AxisValueArray>
 <ElidedFallbackNameID value="2"/>  <!-- Italic -->

--- a/tests/data/OpenSansCondensed[wght]_STAT.ttx
+++ b/tests/data/OpenSansCondensed[wght]_STAT.ttx
@@ -88,7 +88,7 @@
   <AxisValue index="9" Format="3">
     <AxisIndex value="2"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="280"/>  <!-- Normal -->
+    <ValueNameID value="466"/>  <!-- Roman -->
     <Value value="0.0"/>
     <LinkedValue value="1.0"/>
   </AxisValue>
@@ -96,12 +96,12 @@
     <AxisIndex value="3"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
     <ValueNameID value="280"/>  <!-- Normal -->
-    <Value value="0.0"/>
+    <Value value="100.0"/>
   </AxisValue>
   <AxisValue index="11" Format="3">
     <AxisIndex value="4"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="280"/>  <!-- Normal -->
+    <ValueNameID value="466"/>  <!-- Roman -->
     <Value value="0.0"/>
     <LinkedValue value="1.0"/>
   </AxisValue>

--- a/tests/data/OpenSans[wdth,wght]_STAT.ttx
+++ b/tests/data/OpenSans[wdth,wght]_STAT.ttx
@@ -83,14 +83,14 @@
   <AxisValue index="9" Format="3">
     <AxisIndex value="2"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="283"/>  <!-- Normal -->
+    <ValueNameID value="285"/>  <!-- Roman -->
     <Value value="0.0"/>
     <LinkedValue value="1.0"/>
   </AxisValue>
   <AxisValue index="10" Format="3">
     <AxisIndex value="3"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="283"/>  <!-- Normal -->
+    <ValueNameID value="285"/>  <!-- Roman -->
     <Value value="0.0"/>
     <LinkedValue value="1.0"/>
   </AxisValue>

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -448,7 +448,7 @@ def test_stat(fp, sibling_fps):
     build_stat(font, siblings)
     stat_fp = fp.replace(".ttf", "_STAT.ttx")
 
-    ### output good files
+    ## output good files
     # with open(stat_fp, "w") as doc:
     #    got = dump(font["STAT"], font)
     #    doc.write(got)


### PR DESCRIPTION
Currently, if we're generating a STAT table for a variable font family which contains Roman and Italic fonts, the Roman font's Italic axis will include an axisvalue whose name is "Normal" when we actually want "Roman". We're getting this due to me previously hardcoding the implementation. The new implementation will now get the default axisvalue for the given axis and then elide it.

Fixes https://github.com/google/fonts/pull/5591

cc @RosaWagner 