### PR TITLE
Update Roboto Flex optical size expected string casing in ttx

### DIFF
--- a/tests/data/RobotoFlex[GRAD,XOPQ,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght]_STAT.ttx
+++ b/tests/data/RobotoFlex[GRAD,XOPQ,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght]_STAT.ttx
@@ -14,7 +14,7 @@
   </Axis>
   <Axis index="2">
     <AxisTag value="opsz"/>
-    <AxisNameID value="320"/>  <!-- Optical size -->
+    <AxisNameID value="320"/>  <!-- Optical Size -->
     <AxisOrdering value="2"/>
   </Axis>
   <Axis index="3">


### PR DESCRIPTION
Make expected values consistent with changes introduced at https://github.com/googlefonts/axisregistry/pull/89