### PR TITLE
Fix a typo in the WONK axis description

### DIFF
--- a/Lib/axisregistry/data/wonky.textproto
+++ b/Lib/axisregistry/data/wonky.textproto
@@ -16,7 +16,7 @@ fallback {
 fallback_only: true
 illustration_url: "wonky.svg"
 description:
-  "Toggle the subsitution of wonky forms. 'Off' (0) maintains more"
+  "Toggle the substitution of wonky forms. 'Off' (0) maintains more"
   " conventional letterforms, while 'On' (1) maintains wonky"
   " letterforms, such as leaning stems in roman, or flagged"
   " ascenders in italic. These forms are also controlled by"


### PR DESCRIPTION
This PR fixes a typo that was spotted while reviewing the Google Fonts axis definitions https://fonts.google.com/variablefonts#axis-definitions

<img width="910" alt="Screen Shot 2023-01-06 at 12 33 08 PM" src="https://user-images.githubusercontent.com/20364153/211095093-6576463e-75eb-4304-a491-a7b78c1341b1.png">