### PR TITLE
Also protect STAT table name IDs from the axis list

### DIFF
--- a/Lib/axisregistry/__init__.py
+++ b/Lib/axisregistry/__init__.py
@@ -338,9 +338,13 @@ def build_fvar_instances(ttFont, axis_dflts={}):
     stat_nameids = []
     if "STAT" in ttFont:
         if ttFont["STAT"].table.AxisValueCount > 0:
-            stat_nameids = [
+            stat_nameids.extend(
                 av.ValueNameID for av in ttFont["STAT"].table.AxisValueArray.AxisValue
-            ]
+            )
+        if ttFont["STAT"].table.DesignAxisCount > 0:
+            stat_nameids.extend(
+                av.AxisNameID for av in ttFont["STAT"].table.DesignAxisRecord.Axis
+            )
 
     # rm old fvar subfamily and ps name records
     for inst in fvar.instances:


### PR DESCRIPTION
When rebuilding the name table after replacing fvar instances, we make sure that we don't delete any name IDs which are used in the STAT table. However, currently we only look in the axis value list of the STAT table; we also need to read the design axis list as well.