### PR TITLE
Adding [SHRP] Sharpness custom Axis

### DIFF
--- a/Lib/axisregistry/data/sharpness.textproto
+++ b/Lib/axisregistry/data/sharpness.textproto
@@ -1,0 +1,15 @@
+# ROND based on internal project
+tag: "SHRP"
+display_name: "Sharpness"
+min_value: 0
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0
+}
+fallback_only: false
+description:
+  "Adjust shapes from angular or blunt default shapes (0%)"
+  " to become increasingly sharped forms (up to 100%)."

--- a/Lib/axisregistry/data/sharpness.textproto
+++ b/Lib/axisregistry/data/sharpness.textproto
@@ -1,4 +1,4 @@
-# ROND based on internal project
+#SHRP based on https://github.com/monokromskriftforlag/geologisk/
 tag: "SHRP"
 display_name: "Sharpness"
 min_value: 0


### PR DESCRIPTION
This axis is introduced by the Geologica font.

I changed the description, making it somewhat coordinated with how [ROND](https://github.com/googlefonts/axisregistry/blob/main/Lib/axisregistry/data/roundness.textproto) axis was described and clarifying the value ranges.

Ideally, this PR should be included in the same git pull subtree alongside the deletion of `MUTA` and the inclusion of `YALN`