### PR TITLE
Adding [YALN] Y Alignment custom Axis 

### DIFF
--- a/Lib/axisregistry/data/y_alignment.textproto
+++ b/Lib/axisregistry/data/y_alignment.textproto
@@ -1,0 +1,16 @@
+#YALN based on [Wavefont](https://github.com/dy/wavefont)
+tag: "YALN"
+display_name: "Y Alignment"
+min_value: -100
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0
+}
+fallback_only: false
+description:
+  "Align glyphs from their default position (0%),"
+  " usually the baseline, to a lower (-100%)"
+  " or upper (100%) bound."

--- a/Lib/axisregistry/data/y_alignment.textproto
+++ b/Lib/axisregistry/data/y_alignment.textproto
@@ -12,5 +12,5 @@ fallback {
 fallback_only: false
 description:
   "Align glyphs from their default position (0%),"
-  " usually the baseline, to a lower (-100%)"
-  " or upper (100%) bound."
+  " usually the baseline, to an upper (100%)"
+  " or lower (-100%) position."


### PR DESCRIPTION
PR to follow up on the inclusion of the new custom axis `YALN Y Alignment` #106 
Required for the Wavefont.