### PR TITLE
Adding [ARRR] AR Retinal Resolution custom Axis

### DIFF
--- a/Lib/axisregistry/data/ar_retinal_resolution.textproto
+++ b/Lib/axisregistry/data/ar_retinal_resolution.textproto
@@ -1,0 +1,15 @@
+tag: "ARRR"
+display_name: "AR Retinal Resolution"
+min_value: 10
+default_value: 10
+max_value: 60
+precision: 0
+fallback {
+  name: "Default"
+  value: 10.0
+}
+fallback_olny: false
+description: 
+  " Resolution-specific enhancements in AR/VR typefaces to optimize"
+  " rendering across the different resolutions of the headsets"
+  " making designs accessible and easy to read."


### PR DESCRIPTION
PR to follow up on the inclusion of the new custom axis `ARRR AR Retinal Resolution` #132 
Introduced by AR One Sans.