### PR TITLE
Add test for proto wellformedness (no missing required fields)

### DIFF
--- a/tests/test_wellformed.py
+++ b/tests/test_wellformed.py
@@ -1,0 +1,19 @@
+import pytest
+from axisregistry import AxisRegistry
+from axisregistry.axes_pb2 import AxisProto
+
+registry = AxisRegistry()
+
+OPTIONAL_FIELDS = ["illustration_url", "is_parametric"]
+
+
+@pytest.mark.parametrize("axis_tag", registry.keys())
+def test_proto_wellformed(axis_tag):
+    axis = registry[axis_tag]
+    raw_fields = dict([(k.name, v) for k, v in axis.ListFields()])
+    for field in AxisProto.DESCRIPTOR.fields:
+        field_name = field.name
+        if field_name in OPTIONAL_FIELDS:
+            continue
+        assert field_name in raw_fields, field_name
+        assert raw_fields[field_name] is not None, field_name


### PR DESCRIPTION
Although the proto definition suggests that some fields are optional, actually most fields are required. We gather a list of *actually* optional fields, and check that everything in the registry has values present for the rest.