### PR TITLE
Adding [BLED] Bleed custom Axis

### DIFF
--- a/Lib/axisregistry/data/bleed.textproto
+++ b/Lib/axisregistry/data/bleed.textproto
@@ -1,0 +1,17 @@
+# BLED based on https://github.com/jenskutilek/homecomputer-fonts
+tag: "BLED"
+display_name: "Bleed"
+min_value: 0
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0.0
+}
+fallback_only: false
+description: 
+  "Bleed adjusts the overall darkness in the typographic color of strokes or other forms, without"
+  " any changes in overall width, line breaks, or page layout. Negative values make the font appearance"
+  " lighter, while positive values make it darker, similarly to ink bleed or dot gain on paper, commonly"
+  " seen in printed and typewritten materials."

--- a/Lib/axisregistry/data/bleed.textproto
+++ b/Lib/axisregistry/data/bleed.textproto
@@ -13,5 +13,4 @@ fallback_only: false
 description: 
   "Bleed adjusts the overall darkness in the typographic color of strokes or other forms, without"
   " any changes in overall width, line breaks, or page layout. Negative values make the font appearance"
-  " lighter, while positive values make it darker, similarly to ink bleed or dot gain on paper, commonly"
-  " seen in printed and typewritten materials."
+  " lighter, while positive values make it darker, similarly to ink bleed or dot gain on paper."


### PR DESCRIPTION
PR to follow up on the inclusion of the new custom axis `[BLED] Bleed` #17 
This axis is introduced by Homecomputer Sixtyfour and Workbench fonts.