### PR TITLE
Update morph.textproto for Honk

### DIFF
--- a/Lib/axisregistry/data/morph.textproto
+++ b/Lib/axisregistry/data/morph.textproto
@@ -1,9 +1,9 @@
-# MORF based on https://github.com/Vectro-Type-Foundry/kablammo, https://github.com/EkType/Honk
+# MORF based on https://github.com/Vectro-Type-Foundry/kablammo
 tag: "MORF"
 display_name: "Morph"
 min_value: 0
 default_value: 0
-max_value: 100
+max_value: 120
 precision: 0
 fallback {
   name: "Default"
@@ -13,3 +13,4 @@ fallback_only: false
 description:
   "Letterforms morph: Changing in unconventional ways,"
   " that don't alter other attributes, like width or weight."
+  " The range from 0 to 120 can be understood as seconds."

--- a/Lib/axisregistry/data/morph.textproto
+++ b/Lib/axisregistry/data/morph.textproto
@@ -1,9 +1,9 @@
-# MORF based on https://github.com/Vectro-Type-Foundry/kablammo 
+# MORF based on https://github.com/Vectro-Type-Foundry/kablammo, https://github.com/EkType/Honk
 tag: "MORF"
 display_name: "Morph"
 min_value: 0
 default_value: 0
-max_value: 60
+max_value: 100
 precision: 0
 fallback {
   name: "Default"
@@ -13,4 +13,3 @@ fallback_only: false
 description:
   "Letterforms morph: Changing in unconventional ways,"
   " that don't alter other attributes, like width or weight."
-  " The range from 0 to 60 can be understood as seconds."


### PR DESCRIPTION
https://github.com/EkType/Honk

Adjusting maximum value and remove seconds reference from description to accommodate to replace Honk’s STYL implementation with MORF.