### PR TITLE
Allow less aggressive renames

### DIFF
--- a/Lib/axisregistry/__init__.py
+++ b/Lib/axisregistry/__init__.py
@@ -255,7 +255,9 @@ def build_stat(ttFont, sibling_ttFonts=[]):
     buildStatTable(ttFont, res, macNames=False)
 
 
-def build_name_table(ttFont, family_name=None, style_name=None, siblings=[]):
+def build_name_table(
+    ttFont, family_name=None, style_name=None, siblings=[], aggressive=True
+):
     from fontTools.varLib.instancer import setRibbiBits
 
     log.info("Building name table")
@@ -263,9 +265,13 @@ def build_name_table(ttFont, family_name=None, style_name=None, siblings=[]):
     family_name = family_name if family_name else name_table.getBestFamilyName()
     style_name = style_name if style_name else name_table.getBestSubFamilyName()
     if is_variable(ttFont):
-        build_vf_name_table(ttFont, family_name, siblings=siblings)
+        build_vf_name_table(
+            ttFont, family_name, siblings=siblings, aggressive=aggressive
+        )
     else:
-        build_static_name_table_v1(ttFont, family_name, style_name)
+        build_static_name_table_v1(
+            ttFont, family_name, style_name, aggressive=aggressive
+        )
 
     # Set bits
     style_name = name_table.getBestSubFamilyName()
@@ -297,14 +303,16 @@ def _fvar_instance_collisions(ttFont, siblings=[]):
     return len(family_styles) != len(set(family_styles))
 
 
-def build_vf_name_table(ttFont, family_name, siblings=[]):
+def build_vf_name_table(ttFont, family_name, siblings=[], aggressive=True):
     # VF name table should reflect the 0 origin of the font!
     assert is_variable(ttFont), "Not a VF!"
     style_name = _vf_style_name(ttFont, family_name)
     if _fvar_instance_collisions(ttFont, siblings):
-        build_static_name_table_v1(ttFont, family_name, style_name)
+        build_static_name_table_v1(
+            ttFont, family_name, style_name, aggressive=aggressive
+        )
     else:
-        build_static_name_table(ttFont, family_name, style_name)
+        build_static_name_table(ttFont, family_name, style_name, aggressive=aggressive)
     build_variations_ps_name(ttFont, family_name)
 
 
@@ -432,7 +440,7 @@ def build_fvar_instances(ttFont, axis_dflts={}):
     fvar.instances = instances
 
 
-def build_static_name_table(ttFont, family_name, style_name):
+def build_static_name_table(ttFont, family_name, style_name, aggressive=True):
     # stip mac names
     name_table = ttFont["name"]
     name_table.removeNames(platformID=1)
@@ -504,23 +512,26 @@ def build_static_name_table(ttFont, family_name, style_name):
         name_table.setName(v, *k)
 
     # Replace occurences of old family name in untouched records
-    skip_ids = [i.numerator for i in NameID]
-    for r in ttFont["name"].names:
-        if r.nameID in skip_ids:
-            continue
-        current = r.toUnicode()
-        if existing_name not in current:
-            continue
-        if " " not in current:
-            replacement = current.replace(existing_name, family_name).replace(" ", "")
-        else:
-            replacement = current.replace(existing_name, family_name)
-        ttFont["name"].setName(
-            replacement, r.nameID, r.platformID, r.platEncID, r.langID
-        )
+    if aggressive:
+        skip_ids = [i.numerator for i in NameID]
+        for r in ttFont["name"].names:
+            if r.nameID in skip_ids:
+                continue
+            current = r.toUnicode()
+            if existing_name not in current:
+                continue
+            if " " not in current:
+                replacement = current.replace(existing_name, family_name).replace(
+                    " ", ""
+                )
+            else:
+                replacement = current.replace(existing_name, family_name)
+            ttFont["name"].setName(
+                replacement, r.nameID, r.platformID, r.platEncID, r.langID
+            )
 
 
-def build_static_name_table_v1(ttFont, family_name, style_name):
+def build_static_name_table_v1(ttFont, family_name, style_name, aggressive=True):
     """Pre VF name tables, this version can only accept wght + ital"""
     non_weight_tokens = []
     v1_tokens = []
@@ -545,7 +556,7 @@ def build_static_name_table_v1(ttFont, family_name, style_name):
     style_name = style_name or "Regular"
     log.debug(f"New family name: {family_name}")
     log.debug(f"New style name: {style_name}")
-    build_static_name_table(ttFont, family_name, style_name)
+    build_static_name_table(ttFont, family_name, style_name, aggressive)
 
 
 def build_filename(ttFont):

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -321,6 +321,37 @@ def test_name_table(fp, family_name, style_name, siblings, expected):
     _test_names(font, expected)
 
 
+def test_name_table_aggression():
+    font = TTFont(mavenpro_fp)
+    build_name_table(font, "Raven Am", "Regular", aggressive=True)
+    _test_names(
+        font,
+        {
+            (
+                0,
+                3,
+                1,
+                0x409,
+            ): 'Copyright 2011 The Raven Am Project Authors (http://www.vissol.co.uk/mavenpro/), with Reserved Font Name "Raven Am".',
+            (4, 3, 1, 0x409): "Raven Am Regular",
+        },
+    )
+    font = TTFont(mavenpro_fp)
+    build_name_table(font, "Raven Am", "Regular", aggressive=False)
+    _test_names(
+        font,
+        {
+            (
+                0,
+                3,
+                1,
+                0x409,
+            ): 'Copyright 2011 The Maven Pro Project Authors (http://www.vissol.co.uk/mavenpro/), with Reserved Font Name "Maven Pro".',
+            (4, 3, 1, 0x409): "Raven Am Regular",
+        },
+    )
+
+
 @pytest.mark.parametrize(
     "font_fp, dflt_coords, expected",
     [


### PR DESCRIPTION
Allows for a family of related fonts to share same (untouched) name IDs, such as copyright. Test says it all:

```python
    font = TTFont(mavenpro_fp)
    build_name_table(font, "Raven Am", "Regular", aggressive=True)
    _test_names(font, {
        (0, 3, 1, 0x409): 'Copyright 2011 The Raven Am Project Authors (http://www.vissol.co.uk/mavenpro/), with Reserved Font Name "Raven Am".',
        (4, 3, 1, 0x409): "Raven Am Regular"
    })

    font = TTFont(mavenpro_fp)
    build_name_table(font, "Raven Am", "Regular", aggressive=False)
    _test_names(font, {
        (0, 3, 1, 0x409): 'Copyright 2011 The Maven Pro Project Authors (http://www.vissol.co.uk/mavenpro/), with Reserved Font Name "Maven Pro".',
        (4, 3, 1, 0x409): "Raven Am Regular"
    })
```