### PR TITLE
Add Vertical Position of Paint 2 [YPN2] axis

### DIFF
--- a/Lib/axisregistry/data/y_position_paint_2.textproto
+++ b/Lib/axisregistry/data/y_position_paint_2.textproto
@@ -1,0 +1,15 @@
+#Vertical Position Paint 2, based on https://github.com/petrvanblokland/TYPETR-Bitcount
+tag: "YPN2"
+display_name: "Vertical Position of Paint 2"
+min_value: -100
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0
+}
+fallback_only: false
+description: 
+  "The position of the paint moves up and down. Negative values"
+  " move down and positive values move up. Paint 2 is in front of Paint 1."


### PR DESCRIPTION
This PR adds the second Vertical Position axis discussed in https://github.com/googlefonts/axisregistry/issues/116, introduced by Bitcount fonts.

Related PR https://github.com/googlefonts/axisregistry/pull/171