### PR TITLE
build_name_table: Set stylename to no longer reflect the font's origin master

### DIFF
--- a/tests/data/OpenSans-Italic[wdth,wght]_STAT.ttx
+++ b/tests/data/OpenSans-Italic[wdth,wght]_STAT.ttx
@@ -28,56 +28,56 @@
   <AxisValue index="0" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="280"/>  <!-- Light -->
+    <ValueNameID value="283"/>  <!-- Light -->
     <Value value="300.0"/>
   </AxisValue>
   <AxisValue index="1" Format="3">
     <AxisIndex value="0"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="281"/>  <!-- Regular -->
+    <ValueNameID value="284"/>  <!-- Regular -->
     <Value value="400.0"/>
     <LinkedValue value="700.0"/>
   </AxisValue>
   <AxisValue index="2" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="282"/>  <!-- Medium -->
+    <ValueNameID value="285"/>  <!-- Medium -->
     <Value value="500.0"/>
   </AxisValue>
   <AxisValue index="3" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="283"/>  <!-- SemiBold -->
+    <ValueNameID value="286"/>  <!-- SemiBold -->
     <Value value="600.0"/>
   </AxisValue>
   <AxisValue index="4" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="284"/>  <!-- Bold -->
+    <ValueNameID value="287"/>  <!-- Bold -->
     <Value value="700.0"/>
   </AxisValue>
   <AxisValue index="5" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="285"/>  <!-- ExtraBold -->
+    <ValueNameID value="288"/>  <!-- ExtraBold -->
     <Value value="800.0"/>
   </AxisValue>
   <AxisValue index="6" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="286"/>  <!-- Condensed -->
+    <ValueNameID value="280"/>  <!-- Condensed -->
     <Value value="75.0"/>
   </AxisValue>
   <AxisValue index="7" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="287"/>  <!-- SemiCondensed -->
+    <ValueNameID value="281"/>  <!-- SemiCondensed -->
     <Value value="87.5"/>
   </AxisValue>
   <AxisValue index="8" Format="1">
     <AxisIndex value="1"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="288"/>  <!-- Normal -->
+    <ValueNameID value="282"/>  <!-- Normal -->
     <Value value="100.0"/>
   </AxisValue>
   <AxisValue index="9" Format="1">

--- a/tests/data/OpenSansCondensed-Italic[wght]_STAT.ttx
+++ b/tests/data/OpenSansCondensed-Italic[wght]_STAT.ttx
@@ -14,12 +14,12 @@
   </Axis>
   <Axis index="2">
     <AxisTag value="ital"/>
-    <AxisNameID value="273"/>  <!-- Italic -->
+    <AxisNameID value="260"/>  <!-- Italic -->
     <AxisOrdering value="2"/>
   </Axis>
   <Axis index="3">
     <AxisTag value="ital"/>
-    <AxisNameID value="273"/>  <!-- Italic -->
+    <AxisNameID value="260"/>  <!-- Italic -->
     <AxisOrdering value="3"/>
   </Axis>
   <Axis index="4">
@@ -33,50 +33,50 @@
   <AxisValue index="0" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="521"/>  <!-- Thin -->
+    <ValueNameID value="278"/>  <!-- Thin -->
     <Value value="100.0"/>
   </AxisValue>
   <AxisValue index="1" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="522"/>  <!-- ExtraLight -->
+    <ValueNameID value="279"/>  <!-- ExtraLight -->
     <Value value="200.0"/>
   </AxisValue>
   <AxisValue index="2" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="523"/>  <!-- Light -->
+    <ValueNameID value="280"/>  <!-- Light -->
     <Value value="300.0"/>
   </AxisValue>
   <AxisValue index="3" Format="3">
     <AxisIndex value="0"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="524"/>  <!-- Regular -->
+    <ValueNameID value="281"/>  <!-- Regular -->
     <Value value="400.0"/>
     <LinkedValue value="700.0"/>
   </AxisValue>
   <AxisValue index="4" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="525"/>  <!-- Medium -->
+    <ValueNameID value="282"/>  <!-- Medium -->
     <Value value="500.0"/>
   </AxisValue>
   <AxisValue index="5" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="526"/>  <!-- SemiBold -->
+    <ValueNameID value="283"/>  <!-- SemiBold -->
     <Value value="600.0"/>
   </AxisValue>
   <AxisValue index="6" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="527"/>  <!-- Bold -->
+    <ValueNameID value="284"/>  <!-- Bold -->
     <Value value="700.0"/>
   </AxisValue>
   <AxisValue index="7" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="528"/>  <!-- ExtraBold -->
+    <ValueNameID value="285"/>  <!-- ExtraBold -->
     <Value value="800.0"/>
   </AxisValue>
   <AxisValue index="8" Format="1">
@@ -94,14 +94,14 @@
   <AxisValue index="10" Format="3">
     <AxisIndex value="3"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="529"/>  <!-- Roman -->
+    <ValueNameID value="521"/>  <!-- Roman -->
     <Value value="0.0"/>
     <LinkedValue value="1.0"/>
   </AxisValue>
   <AxisValue index="11" Format="1">
     <AxisIndex value="4"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="530"/>  <!-- Normal -->
+    <ValueNameID value="522"/>  <!-- Normal -->
     <Value value="100.0"/>
   </AxisValue>
 </AxisValueArray>

--- a/tests/data/OpenSansCondensed[wght]_STAT.ttx
+++ b/tests/data/OpenSansCondensed[wght]_STAT.ttx
@@ -33,19 +33,19 @@
   <AxisValue index="0" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="270"/>  <!-- Thin -->
+    <ValueNameID value="258"/>  <!-- Thin -->
     <Value value="100.0"/>
   </AxisValue>
   <AxisValue index="1" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="283"/>  <!-- ExtraLight -->
+    <ValueNameID value="271"/>  <!-- ExtraLight -->
     <Value value="200.0"/>
   </AxisValue>
   <AxisValue index="2" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="272"/>  <!-- Light -->
+    <ValueNameID value="259"/>  <!-- Light -->
     <Value value="300.0"/>
   </AxisValue>
   <AxisValue index="3" Format="3">
@@ -58,25 +58,25 @@
   <AxisValue index="4" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="286"/>  <!-- Medium -->
+    <ValueNameID value="274"/>  <!-- Medium -->
     <Value value="500.0"/>
   </AxisValue>
   <AxisValue index="5" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="275"/>  <!-- SemiBold -->
+    <ValueNameID value="261"/>  <!-- SemiBold -->
     <Value value="600.0"/>
   </AxisValue>
   <AxisValue index="6" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="276"/>  <!-- Bold -->
+    <ValueNameID value="262"/>  <!-- Bold -->
     <Value value="700.0"/>
   </AxisValue>
   <AxisValue index="7" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="277"/>  <!-- ExtraBold -->
+    <ValueNameID value="263"/>  <!-- ExtraBold -->
     <Value value="800.0"/>
   </AxisValue>
   <AxisValue index="8" Format="1">

--- a/tests/data/OpenSans[wdth,wght]_STAT.ttx
+++ b/tests/data/OpenSans[wdth,wght]_STAT.ttx
@@ -41,7 +41,7 @@
   <AxisValue index="2" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="280"/>  <!-- Medium -->
+    <ValueNameID value="283"/>  <!-- Medium -->
     <Value value="500.0"/>
   </AxisValue>
   <AxisValue index="3" Format="1">
@@ -65,19 +65,19 @@
   <AxisValue index="6" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="281"/>  <!-- Condensed -->
+    <ValueNameID value="280"/>  <!-- Condensed -->
     <Value value="75.0"/>
   </AxisValue>
   <AxisValue index="7" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="282"/>  <!-- SemiCondensed -->
+    <ValueNameID value="281"/>  <!-- SemiCondensed -->
     <Value value="87.5"/>
   </AxisValue>
   <AxisValue index="8" Format="1">
     <AxisIndex value="1"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="283"/>  <!-- Normal -->
+    <ValueNameID value="282"/>  <!-- Normal -->
     <Value value="100.0"/>
   </AxisValue>
   <AxisValue index="9" Format="3">

--- a/tests/data/RobotoFlex[GRAD,XOPQ,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght]_STAT.ttx
+++ b/tests/data/RobotoFlex[GRAD,XOPQ,XTRA,YOPQ,YTAS,YTDE,YTFI,YTLC,YTUC,opsz,slnt,wdth,wght]_STAT.ttx
@@ -4,67 +4,67 @@
 <DesignAxisRecord>
   <Axis index="0">
     <AxisTag value="wght"/>
-    <AxisNameID value="309"/>  <!-- Weight -->
+    <AxisNameID value="347"/>  <!-- Weight -->
     <AxisOrdering value="0"/>
   </Axis>
   <Axis index="1">
     <AxisTag value="wdth"/>
-    <AxisNameID value="310"/>  <!-- Width -->
+    <AxisNameID value="339"/>  <!-- Width -->
     <AxisOrdering value="1"/>
   </Axis>
   <Axis index="2">
     <AxisTag value="opsz"/>
-    <AxisNameID value="320"/>  <!-- Optical Size -->
+    <AxisNameID value="319"/>  <!-- Optical Size -->
     <AxisOrdering value="2"/>
   </Axis>
   <Axis index="3">
     <AxisTag value="GRAD"/>
-    <AxisNameID value="340"/>  <!-- Grade -->
+    <AxisNameID value="309"/>  <!-- Grade -->
     <AxisOrdering value="3"/>
   </Axis>
   <Axis index="4">
     <AxisTag value="slnt"/>
-    <AxisNameID value="341"/>  <!-- Slant -->
+    <AxisNameID value="348"/>  <!-- Slant -->
     <AxisOrdering value="4"/>
   </Axis>
   <Axis index="5">
     <AxisTag value="XTRA"/>
-    <AxisNameID value="343"/>  <!-- Counter Width -->
+    <AxisNameID value="351"/>  <!-- Counter Width -->
     <AxisOrdering value="5"/>
   </Axis>
   <Axis index="6">
     <AxisTag value="XOPQ"/>
-    <AxisNameID value="344"/>  <!-- Thick Stroke -->
+    <AxisNameID value="352"/>  <!-- Thick Stroke -->
     <AxisOrdering value="6"/>
   </Axis>
   <Axis index="7">
     <AxisTag value="YOPQ"/>
-    <AxisNameID value="345"/>  <!-- Thin Stroke -->
+    <AxisNameID value="353"/>  <!-- Thin Stroke -->
     <AxisOrdering value="7"/>
   </Axis>
   <Axis index="8">
     <AxisTag value="YTLC"/>
-    <AxisNameID value="346"/>  <!-- Lowercase Height -->
+    <AxisNameID value="354"/>  <!-- Lowercase Height -->
     <AxisOrdering value="8"/>
   </Axis>
   <Axis index="9">
     <AxisTag value="YTUC"/>
-    <AxisNameID value="347"/>  <!-- Uppercase Height -->
+    <AxisNameID value="355"/>  <!-- Uppercase Height -->
     <AxisOrdering value="9"/>
   </Axis>
   <Axis index="10">
     <AxisTag value="YTAS"/>
-    <AxisNameID value="348"/>  <!-- Ascender Height -->
+    <AxisNameID value="356"/>  <!-- Ascender Height -->
     <AxisOrdering value="10"/>
   </Axis>
   <Axis index="11">
     <AxisTag value="YTDE"/>
-    <AxisNameID value="349"/>  <!-- Descender Depth -->
+    <AxisNameID value="357"/>  <!-- Descender Depth -->
     <AxisOrdering value="11"/>
   </Axis>
   <Axis index="12">
     <AxisTag value="YTFI"/>
-    <AxisNameID value="350"/>  <!-- Figure Height -->
+    <AxisNameID value="358"/>  <!-- Figure Height -->
     <AxisOrdering value="12"/>
   </Axis>
 </DesignAxisRecord>
@@ -128,229 +128,229 @@
   <AxisValue index="9" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="311"/>  <!-- SuperCondensed -->
+    <ValueNameID value="350"/>  <!-- SuperCondensed -->
     <Value value="25.0"/>
   </AxisValue>
   <AxisValue index="10" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="312"/>  <!-- UltraCondensed -->
+    <ValueNameID value="340"/>  <!-- UltraCondensed -->
     <Value value="50.0"/>
   </AxisValue>
   <AxisValue index="11" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="313"/>  <!-- ExtraCondensed -->
+    <ValueNameID value="341"/>  <!-- ExtraCondensed -->
     <Value value="62.5"/>
   </AxisValue>
   <AxisValue index="12" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="314"/>  <!-- Condensed -->
+    <ValueNameID value="342"/>  <!-- Condensed -->
     <Value value="75.0"/>
   </AxisValue>
   <AxisValue index="13" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="315"/>  <!-- SemiCondensed -->
+    <ValueNameID value="343"/>  <!-- SemiCondensed -->
     <Value value="87.5"/>
   </AxisValue>
   <AxisValue index="14" Format="1">
     <AxisIndex value="1"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="316"/>  <!-- Normal -->
+    <ValueNameID value="310"/>  <!-- Normal -->
     <Value value="100.0"/>
   </AxisValue>
   <AxisValue index="15" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="317"/>  <!-- SemiExpanded -->
+    <ValueNameID value="344"/>  <!-- SemiExpanded -->
     <Value value="112.5"/>
   </AxisValue>
   <AxisValue index="16" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="318"/>  <!-- Expanded -->
+    <ValueNameID value="345"/>  <!-- Expanded -->
     <Value value="125.0"/>
   </AxisValue>
   <AxisValue index="17" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="319"/>  <!-- ExtraExpanded -->
+    <ValueNameID value="346"/>  <!-- ExtraExpanded -->
     <Value value="150.0"/>
   </AxisValue>
   <AxisValue index="18" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="321"/>  <!-- 8pt -->
+    <ValueNameID value="320"/>  <!-- 8pt -->
     <Value value="8.0"/>
   </AxisValue>
   <AxisValue index="19" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="322"/>  <!-- 9pt -->
+    <ValueNameID value="321"/>  <!-- 9pt -->
     <Value value="9.0"/>
   </AxisValue>
   <AxisValue index="20" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="323"/>  <!-- 10pt -->
+    <ValueNameID value="322"/>  <!-- 10pt -->
     <Value value="10.0"/>
   </AxisValue>
   <AxisValue index="21" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="324"/>  <!-- 11pt -->
+    <ValueNameID value="323"/>  <!-- 11pt -->
     <Value value="11.0"/>
   </AxisValue>
   <AxisValue index="22" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="325"/>  <!-- 12pt -->
+    <ValueNameID value="324"/>  <!-- 12pt -->
     <Value value="12.0"/>
   </AxisValue>
   <AxisValue index="23" Format="1">
     <AxisIndex value="2"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="326"/>  <!-- 14pt -->
+    <ValueNameID value="325"/>  <!-- 14pt -->
     <Value value="14.0"/>
   </AxisValue>
   <AxisValue index="24" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="327"/>  <!-- 16pt -->
+    <ValueNameID value="326"/>  <!-- 16pt -->
     <Value value="16.0"/>
   </AxisValue>
   <AxisValue index="25" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="328"/>  <!-- 17pt -->
+    <ValueNameID value="327"/>  <!-- 17pt -->
     <Value value="17.0"/>
   </AxisValue>
   <AxisValue index="26" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="329"/>  <!-- 18pt -->
+    <ValueNameID value="328"/>  <!-- 18pt -->
     <Value value="18.0"/>
   </AxisValue>
   <AxisValue index="27" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="330"/>  <!-- 20pt -->
+    <ValueNameID value="329"/>  <!-- 20pt -->
     <Value value="20.0"/>
   </AxisValue>
   <AxisValue index="28" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="331"/>  <!-- 24pt -->
+    <ValueNameID value="330"/>  <!-- 24pt -->
     <Value value="24.0"/>
   </AxisValue>
   <AxisValue index="29" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="332"/>  <!-- 28pt -->
+    <ValueNameID value="331"/>  <!-- 28pt -->
     <Value value="28.0"/>
   </AxisValue>
   <AxisValue index="30" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="333"/>  <!-- 36pt -->
+    <ValueNameID value="332"/>  <!-- 36pt -->
     <Value value="36.0"/>
   </AxisValue>
   <AxisValue index="31" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="334"/>  <!-- 48pt -->
+    <ValueNameID value="333"/>  <!-- 48pt -->
     <Value value="48.0"/>
   </AxisValue>
   <AxisValue index="32" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="335"/>  <!-- 60pt -->
+    <ValueNameID value="334"/>  <!-- 60pt -->
     <Value value="60.0"/>
   </AxisValue>
   <AxisValue index="33" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="336"/>  <!-- 72pt -->
+    <ValueNameID value="335"/>  <!-- 72pt -->
     <Value value="72.0"/>
   </AxisValue>
   <AxisValue index="34" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="337"/>  <!-- 96pt -->
+    <ValueNameID value="336"/>  <!-- 96pt -->
     <Value value="96.0"/>
   </AxisValue>
   <AxisValue index="35" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="338"/>  <!-- 120pt -->
+    <ValueNameID value="337"/>  <!-- 120pt -->
     <Value value="120.0"/>
   </AxisValue>
   <AxisValue index="36" Format="1">
     <AxisIndex value="2"/>
     <Flags value="0"/>
-    <ValueNameID value="339"/>  <!-- 144pt -->
+    <ValueNameID value="338"/>  <!-- 144pt -->
     <Value value="144.0"/>
   </AxisValue>
   <AxisValue index="37" Format="1">
     <AxisIndex value="3"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="316"/>  <!-- Normal -->
+    <ValueNameID value="310"/>  <!-- Normal -->
     <Value value="0.0"/>
   </AxisValue>
   <AxisValue index="38" Format="1">
     <AxisIndex value="4"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="342"/>  <!-- Default -->
+    <ValueNameID value="349"/>  <!-- Default -->
     <Value value="0.0"/>
   </AxisValue>
   <AxisValue index="39" Format="1">
     <AxisIndex value="5"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="316"/>  <!-- Normal -->
+    <ValueNameID value="310"/>  <!-- Normal -->
     <Value value="400.0"/>
   </AxisValue>
   <AxisValue index="40" Format="1">
     <AxisIndex value="6"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="316"/>  <!-- Normal -->
+    <ValueNameID value="310"/>  <!-- Normal -->
     <Value value="88.0"/>
   </AxisValue>
   <AxisValue index="41" Format="1">
     <AxisIndex value="7"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="316"/>  <!-- Normal -->
+    <ValueNameID value="310"/>  <!-- Normal -->
     <Value value="116.0"/>
   </AxisValue>
   <AxisValue index="42" Format="1">
     <AxisIndex value="8"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="316"/>  <!-- Normal -->
+    <ValueNameID value="310"/>  <!-- Normal -->
     <Value value="500.0"/>
   </AxisValue>
   <AxisValue index="43" Format="1">
     <AxisIndex value="9"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="316"/>  <!-- Normal -->
+    <ValueNameID value="310"/>  <!-- Normal -->
     <Value value="725.0"/>
   </AxisValue>
   <AxisValue index="44" Format="1">
     <AxisIndex value="10"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="316"/>  <!-- Normal -->
+    <ValueNameID value="310"/>  <!-- Normal -->
     <Value value="750.0"/>
   </AxisValue>
   <AxisValue index="45" Format="1">
     <AxisIndex value="11"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="316"/>  <!-- Normal -->
+    <ValueNameID value="310"/>  <!-- Normal -->
     <Value value="-250.0"/>
   </AxisValue>
   <AxisValue index="46" Format="1">
     <AxisIndex value="12"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="316"/>  <!-- Normal -->
+    <ValueNameID value="310"/>  <!-- Normal -->
     <Value value="600.0"/>
   </AxisValue>
 </AxisValueArray>

--- a/tests/data/Wavefont[ROND,YALN,wght]_STAT.ttx
+++ b/tests/data/Wavefont[ROND,YALN,wght]_STAT.ttx
@@ -18,7 +18,7 @@
   <AxisValue index="0" Format="1">
     <AxisIndex value="0"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="267"/>  <!-- Default -->
+    <ValueNameID value="268"/>  <!-- Default -->
     <Value value="0.0"/>
   </AxisValue>
   <AxisValue index="1" Format="1">

--- a/tests/data/Wonky[wdth,wght]_STAT.ttx
+++ b/tests/data/Wonky[wdth,wght]_STAT.ttx
@@ -31,7 +31,7 @@
   <AxisValue index="2" Format="1">
     <AxisIndex value="0"/>
     <Flags value="0"/>
-    <ValueNameID value="280"/>  <!-- Medium -->
+    <ValueNameID value="283"/>  <!-- Medium -->
     <Value value="500.0"/>
   </AxisValue>
   <AxisValue index="3" Format="1">
@@ -55,19 +55,19 @@
   <AxisValue index="6" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="281"/>  <!-- Condensed -->
+    <ValueNameID value="280"/>  <!-- Condensed -->
     <Value value="75.0"/>
   </AxisValue>
   <AxisValue index="7" Format="1">
     <AxisIndex value="1"/>
     <Flags value="0"/>
-    <ValueNameID value="282"/>  <!-- SemiCondensed -->
+    <ValueNameID value="281"/>  <!-- SemiCondensed -->
     <Value value="87.5"/>
   </AxisValue>
   <AxisValue index="8" Format="1">
     <AxisIndex value="1"/>
     <Flags value="2"/>  <!-- ElidableAxisValueName -->
-    <ValueNameID value="283"/>  <!-- Normal -->
+    <ValueNameID value="282"/>  <!-- Normal -->
     <Value value="100.0"/>
   </AxisValue>
 </AxisValueArray>

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -210,7 +210,7 @@ def _test_names(ttFont, expected):
                 (6, 3, 1, 0x409): "OpenSans-Regular",
                 (16, 3, 1, 0x409): None,
                 (17, 3, 1, 0x409): None,
-                (25, 3, 1, 0x409): "OpenSans",
+                (25, 3, 1, 0x409): "OpenSansRoman",
             },
         ),
         # Open Sans Italic
@@ -244,7 +244,7 @@ def _test_names(ttFont, expected):
                 (6, 3, 1, 0x409): "OpenSansCondensed-Regular",
                 (16, 3, 1, 0x409): None,
                 (17, 3, 1, 0x409): None,
-                (25, 3, 1, 0x409): "OpenSansCondensed",
+                (25, 3, 1, 0x409): "OpenSansCondensedRoman",
             },
         ),
         # Open Sans Cond Italic
@@ -303,13 +303,11 @@ def _test_names(ttFont, expected):
             None,
             [],
             {
-                (1, 3, 1, 0x409): "Playfair SemiExpanded Light",
+                (1, 3, 1, 0x409): "Playfair",
                 (2, 3, 1, 0x409): "Regular",
-                (3, 3, 1, 0x409): "2.000;FTH;Playfair-SemiExpandedLight",
-                (4, 3, 1, 0x409): "Playfair SemiExpanded Light",
-                (6, 3, 1, 0x409): "Playfair-SemiExpandedLight",
-                (16, 3, 1, 0x409): "Playfair",
-                (17, 3, 1, 0x409): "SemiExpanded Light",
+                (3, 3, 1, 0x409): "2.000;FTH;Playfair-Regular",
+                (4, 3, 1, 0x409): "Playfair Regular",
+                (6, 3, 1, 0x409): "Playfair-Regular",
             },
         ),
     ],
@@ -501,10 +499,10 @@ def test_stat(fp, sibling_fps):
     build_stat(font, siblings)
     stat_fp = fp.replace(".ttf", "_STAT.ttx")
 
-    ## output good files
+    # # output good files
     # with open(stat_fp, "w") as doc:
-    #    got = dump(font["STAT"], font)
-    #    doc.write(got)
+    #     got = dump(font["STAT"], font)
+    #     doc.write(got)
 
     with open(stat_fp) as doc:
         expected = doc.read()
@@ -565,12 +563,12 @@ def test_fvar_instance_collisions(fp, sibling_fps, result):
 @pytest.mark.parametrize(
     "fp, result",
     [
-        (roboto_flex_fp, "RobotoFlex"),
-        (opensans_roman_fp, "OpenSans"),
+        (roboto_flex_fp, "RobotoFlexRoman"),
+        (opensans_roman_fp, "OpenSansRoman"),
         (opensans_italic_fp, "OpenSansItalic"),
-        (opensans_cond_roman_fp, "OpenSansCondensed"),
+        (opensans_cond_roman_fp, "OpenSansCondensedRoman"),
         (opensans_cond_italic_fp, "OpenSansCondensedItalic"),
-        (wonky_fp, "Wonky"),
+        (wonky_fp, "WonkyRoman"),
     ],
 )
 def test_build_variations_ps_name(fp, result):


### PR DESCRIPTION
@vv-monsalve has been testing variable fonts in Windows MS Word and she's noticed that our current VF name table are causing some issues. These issues have been reported in several threads, most notably https://github.com/fonttools/fontbakery/issues/2179.

Currently, our variable font name tables reflect the origin master of the font. I still maintain this is technically correct and follows the spec. However, Adobe's Source Sans doesn't do this and it seems to work better in MS Word so I've adopted the Adobe approach for now. Dave C, Chris, Viviana have all agreed this approach works better.