### PR TITLE
XELA default changed to 0

### DIFF
--- a/Lib/axisregistry/data/x_element_alignment.textproto
+++ b/Lib/axisregistry/data/x_element_alignment.textproto
@@ -2,7 +2,7 @@
 tag: "XELA"
 display_name: "Horizontal Element Alignment"
 min_value: -100.0
-default_value: -1
+default_value: 0.0
 max_value: 100.0
 precision: 0
 fallback {


### PR DESCRIPTION
The default value was always supposed to be `0`. This will unblock [Sixtyfour Convergence](https://github.com/google/fonts/pull/7919) 