### PR TITLE
Update width.textproto

### DIFF
--- a/Lib/axisregistry/data/width.textproto
+++ b/Lib/axisregistry/data/width.textproto
@@ -7,7 +7,7 @@ default_value: 100
 precision: -1
 # Instance values based on https://docs.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass
 fallback {
-  name: "SuperCondensed"
+  name: "HyperCondensed"
   value: 25
 }
 fallback {


### PR DESCRIPTION
Per a UXR study with Hilary today, a user reported they felt that "Super" is less than "Ultra". 

Since this naming is outside the OT Spec, we could consider renaming "SuperCondensed" to "HyperCondensed". 