### PR TITLE
Adding [YEXT] Vertical Extension axis

### DIFF
--- a/Lib/axisregistry/data/y_vertical_extension.textproto
+++ b/Lib/axisregistry/data/y_vertical_extension.textproto
@@ -1,0 +1,16 @@
+# YEXT based on https://github.com/TypeTogether/Playwrite
+tag: "YEXT"
+display_name: "Vertical Extension"
+min_value: 0
+default_value: 0
+max_value: 100
+precision: 0
+fallback {
+  name: "Default"
+  value: 0
+}
+fallback_only: false
+description: "The axis extends glyphs in the Y dimension, such as the
+  Cap Height, Ascender and Descender lengths. This is a relative axis,
+  starting at 0% and going to the typeface's individual maximum
+  extent at 100%."

--- a/Lib/axisregistry/data/y_vertical_extension.textproto
+++ b/Lib/axisregistry/data/y_vertical_extension.textproto
@@ -10,7 +10,7 @@ fallback {
   value: 0
 }
 fallback_only: false
-description: "The axis extends glyphs in the Y dimension, such as the
-  Cap Height, Ascender and Descender lengths. This is a relative axis,
-  starting at 0% and going to the typeface's individual maximum
-  extent at 100%."
+description: "The axis extends glyphs in the Y dimension, such as the "
+  "Cap Height, Ascender and Descender lengths. This is a relative axis, "
+  "starting at 0% and going to the typeface's individual maximum "
+  "extent at 100%."


### PR DESCRIPTION
PR to follow up on the inclusion of the new custom axis `YEXT Vertical Extension` following the latest definitions agreed on https://github.com/googlefonts/axisregistry/issues/135#issuecomment-2052244984

The Playwrite project defined this Axis. But we should register it now since Emery Cubic https://github.com/google/fonts/issues/6124 needs it