### PR TITLE
Do not add Mac names when populating the fvar table

### DIFF
--- a/Lib/axisregistry/__init__.py
+++ b/Lib/axisregistry/__init__.py
@@ -58,6 +58,10 @@ GF_STATIC_STYLES = OrderedDict(
     ]
 )
 
+# The platforms to include when adding records to the `name` table, which
+# differs from fontTools' default.
+NAME_PLATFORMS = ((3, 1, 0x409),)
+
 
 def load_protobuf(klass, data):
     message = klass()
@@ -442,9 +446,9 @@ def build_fvar_instances(ttFont, axis_dflts={}):
                     coordinates["slnt"] = slnt_axis.minValue
 
             inst = NamedInstance()
-            inst.subfamilyNameID = name_table.addName(name)
+            inst.subfamilyNameID = name_table.addName(name, platforms=NAME_PLATFORMS)
             inst.postscriptNameID = name_table.addName(
-                f"{family_name}-{name}".replace(" ", "")
+                f"{family_name}-{name}".replace(" ", ""), platforms=NAME_PLATFORMS
             )
             inst.coordinates = coordinates
             log.debug(f"Adding fvar instance: {name}: {coordinates}")


### PR DESCRIPTION
See googlefonts/gftools#469

As of the latest Font Bakery release, [the no_mac_entries check has been promoted to the Universal profile](https://github.com/fonttools/fontbakery/blob/main/CHANGELOG.md#0130a0-2024-sep-13), but by default, gftools and axisregistry insert Mac names when populating STAT and fvar.

googlefonts/gftools#1077 has been merged to prevent adding Mac names to STAT, and so this PR follows up to prevent Mac names from being added to fvar too. This is already the behaviour of the in-progress Rust port of axisregistry, and so only the original Python version has been adjusted.

This is the right approach for the particular project I am looking at, but I would like to confirm that this is the right fix - as opposed to, e.g., making the Mac names opt-out - to make sure that this will not have unintended consequences for other consumers of axisregistry, for static TTFs destined for legacy environments, or similar.