### PR TITLE
Pin fontations crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ bytes = "1.7.1"
 prost = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-write-fonts = { version = "0", optional = true, features = ["read"] }
-skrifa = { version = "0", optional = true }
+write-fonts = { version = "0.37.0", optional = true, features = ["read"] }
+skrifa = { version = "0.30.0", optional = true }
 indexmap = "2.7.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This will prevent future breakage as new versions of these crates are released; they can be manually updated as needed.