### PR TITLE
Resolve logger warnings

### DIFF
--- a/Lib/axisregistry/__init__.py
+++ b/Lib/axisregistry/__init__.py
@@ -114,7 +114,7 @@ class AxisRegistry:
         }
         for axis in axes_in_font:
             if axis not in self.keys():
-                log.warn(f"Axis {axis} not found in GF Axis Registry!")
+                log.warning(f"Axis {axis} not found in GF Axis Registry!")
                 continue
             for fallback in self[axis].fallback:
                 if (


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
