### PR TITLE
X Transparency: Increase max_value from 2000 to 3330

### DIFF
--- a/Lib/axisregistry/data/x_transparent.textproto
+++ b/Lib/axisregistry/data/x_transparent.textproto
@@ -2,7 +2,7 @@
 tag: "XTRA"
 display_name: "Counter Width"
 min_value: -1000
-max_value: 2000
+max_value: 3330
 default_value: 400
 precision: 0
 fallback {


### PR DESCRIPTION
Crispy has a rather huge X Transparency axis. The old value is probably from Roboto Flex or another Flex family where it's much smaller.