### PR TITLE
wdth: Increase max val to 300

### DIFF
--- a/Lib/axisregistry/data/width.textproto
+++ b/Lib/axisregistry/data/width.textproto
@@ -2,7 +2,7 @@
 tag: "wdth"
 display_name: "Width"
 min_value: 25
-max_value: 200
+max_value: 300
 default_value: 100
 precision: -1
 # Instance values based on https://docs.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass


### PR DESCRIPTION
Crispy is wrapping up and it will be the widest font in our collection.


Due to the extreme wideness, we decided to set its max width value to 300. The Axis Reg currently has a max value of 200.

I previously argued that we shouldn't set it past 200, due to the relationship with the `OS/2.usWidthClass` field. However, the MS [spec](https://learn.microsoft.com/en-us/typography/opentype/spec/dvaraxistag_wdth) doesn't mention a maximum value like it does for the wght axis so I think we can go past 200.