### PR TITLE
Add Enlarge [ENLA]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+#lib/
+#lib64/
 parts/
 sdist/
 var/

--- a/Lib/axisregistry/data/enlarge.textproto
+++ b/Lib/axisregistry/data/enlarge.textproto
@@ -1,0 +1,21 @@
+# ENLA based on https://github.com/psb1558/Junicode-font
+tag: "ENLA"
+display_name: "Enlarge"
+min_value: 0.0
+default_value: 0.0
+max_value: 100
+precision: -2
+fallback {
+  name: "Normal"
+  value: 0.0
+}
+fallback {
+  name: "Enlarge"
+  value: 100
+}
+fallback_only: false
+description:
+  "Scales lowercase letters to an intermediate size between minuscule and"
+  " majuscule, as used in medieval manuscripts for enlarged minuscules at"
+  " sentence openings. Adjusts x-height and character width continuously"
+  " from 0 (default lowercase) to 1 (fully enlarged)."

--- a/Lib/axisregistry/data/enlarge.textproto
+++ b/Lib/axisregistry/data/enlarge.textproto
@@ -10,7 +10,7 @@ fallback {
   value: 0.0
 }
 fallback {
-  name: "Enlarge"
+  name: "Enlarged"
   value: 100
 }
 fallback_only: false

--- a/Lib/axisregistry/data/enlarge.textproto
+++ b/Lib/axisregistry/data/enlarge.textproto
@@ -18,4 +18,5 @@ description:
   "Scales lowercase letters to an intermediate size between minuscule and"
   " majuscule, as used in medieval manuscripts for enlarged minuscules at"
   " sentence openings. Adjusts x-height and character width continuously"
-  " from 0 (default lowercase) to 1 (fully enlarged)."
+  " from 0 (default lowercase) to 100 (fully enlarged)."
+  


### PR DESCRIPTION
```
# ENLA based on https://github.com/psb1558/Junicode-font
tag: "ENLA"
display_name: "Enlarge"
min_value: 0.0
default_value: 0.0
max_value: 100
precision: -2
fallback {
  name: "Normal"
  value: 0.0
}
fallback {
  name: "Enlarge"
  value: 100
}
fallback_only: false
description:
  "Scales lowercase letters to an intermediate size between minuscule and"
  " majuscule, as used in medieval manuscripts for enlarged minuscules at"
  " sentence openings. Adjusts x-height and character width continuously"
  " from 0 (default lowercase) to 100 (fully enlarged)."
```