### PR TITLE
Add Geometric Form [GEOM]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+#lib/
+#lib64/
 parts/
 sdist/
 var/

--- a/Lib/axisregistry/data/geometricform.textproto
+++ b/Lib/axisregistry/data/geometricform.textproto
@@ -10,4 +10,4 @@ fallback {
   value: 0.00
 }
 fallback_only: false
-description: "Parametrically transforms complex letterforms into simplified geometric shapes like circles, triangles, and squares. This transition can occurs through gradual structural shifting and/or character swaps at specific intervals."
+description: "It transforms complex letterforms into simplified geometric shapes like circles, triangles, and squares. This transition can occurs through gradual structural shifting and/or character swaps at specific intervals."

--- a/Lib/axisregistry/data/geometricform.textproto
+++ b/Lib/axisregistry/data/geometricform.textproto
@@ -1,0 +1,13 @@
+#GEOM based on ([Cal Sans UI & Cal Sans Text](https://github.com/calcom/sans-ui))
+tag: "GEOM"
+display_name: "Geometric Form"
+min_value: 0 
+default_value:  0
+max_value: 100
+precision: 1
+fallback {
+  name: "Default"
+  value: 0.00
+}
+fallback_only: false
+description: "Parametrically transforms complex letterforms into simplified geometric shapes like circles, triangles, and squares. This transition can occurs through gradual structural shifting and/or character swaps at specific intervals."


### PR DESCRIPTION
```
#GEOM based on ([Cal Sans UI & Cal Sans Text](https://github.com/calcom/sans-ui))
tag: "GEOM"
display_name: "Geometric Form"
min_value: 0 
default_value:  0
max_value: 100
precision: 1
fallback {
  name: "Default"
  value: 0.00
}
fallback_only: false
description: "Parametrically transforms complex letterforms into simplified geometric shapes like circles, triangles, and squares. This transition can occurs through gradual structural shifting and/or character swaps at specific intervals."
```

Other description proposal: "Reduces the typeface from idiosyncratic humanist forms toward strict geometric forms. Adjustments range from subtle shape-shifting to full character alternates across the axis."

cc @MarkFonts