### PR TITLE
build_fvar_instances: fix minimum slnt value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -659,7 +659,7 @@ mod fontations_impl {
             .next();
         let min_slnt: Option<f32> = axes
             .iter()
-            .filter(|axis| axis.tag == "ital")
+            .filter(|axis| axis.tag == "slnt")
             .map(|axis| axis.min)
             .next();
 


### PR DESCRIPTION
Went down a rabbit hole wondering why Fontspector's `googlefonts/fvar_instances` didn't like my font and ended up here.